### PR TITLE
Add stream settings for logging stdout/stderr

### DIFF
--- a/src/main/groovy/org/hidetake/groovy/ssh/api/OperationSettings.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/api/OperationSettings.groovy
@@ -28,6 +28,16 @@ class OperationSettings extends Settings<OperationSettings> {
     Boolean logging
 
     /**
+     * An output stream to log standard output.
+     */
+    OutputStream outputStream
+
+    /**
+     * An output stream to log standard error.
+     */
+    OutputStream errorStream
+
+    /**
      * Encoding of input and output stream.
      */
     String encoding
@@ -58,6 +68,8 @@ class OperationSettings extends Settings<OperationSettings> {
                 logging:        findNotNull(right.logging, logging),
                 encoding:       findNotNull(right.encoding, encoding),
                 interaction:    findNotNull(right.interaction, interaction),
+                outputStream:   findNotNull(right.outputStream, outputStream),
+                errorStream:    findNotNull(right.errorStream, errorStream),
                 extensions:     extensions + right.extensions
         )
     }

--- a/src/main/groovy/org/hidetake/groovy/ssh/internal/interaction/LineOutputStream.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/internal/interaction/LineOutputStream.groovy
@@ -16,6 +16,7 @@ class LineOutputStream extends OutputStream {
     private final List<Closure> lineListeners = []
     private final List<Closure<Boolean>> partialListeners = []
     private final List<Closure> loggingListeners = []
+    private final List<OutputStream> linkedStreams = []
 
     private final byteBuffer = new ByteArrayOutputStream(512)
     private lineBuffer = ''
@@ -65,9 +66,20 @@ class LineOutputStream extends OutputStream {
         loggingListeners.add(closure)
     }
 
+    /**
+     * Link the stream.
+     * A byte received by {@link #write(int)} will be written to the stream.
+     *
+     * @param stream the output stream
+     */
+    void linkStream(OutputStream stream) {
+        linkedStreams.add(stream)
+    }
+
     void write(int b) {
         withTryCatch {
             byteBuffer.write(b)
+            linkedStreams*.write(b)
         }
     }
 

--- a/src/main/groovy/org/hidetake/groovy/ssh/internal/operation/DefaultOperations.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/internal/operation/DefaultOperations.groovy
@@ -43,6 +43,7 @@ class DefaultOperations implements Operations {
 
         if (settings.logging) {
             standardOutput.listenLogging { String m -> log.info(m) }
+            if (settings.outputStream) { standardOutput.linkStream(settings.outputStream) }
         }
 
         if (settings.interaction) {
@@ -84,6 +85,8 @@ class DefaultOperations implements Operations {
         if (settings.logging) {
             standardOutput.listenLogging { String m -> log.info(m) }
             standardError.listenLogging { String m -> log.error(m) }
+            if (settings.outputStream) { standardOutput.linkStream(settings.outputStream) }
+            if (settings.errorStream)  { standardError.linkStream(settings.errorStream) }
         }
 
         if (settings.interaction) {
@@ -133,6 +136,8 @@ class DefaultOperations implements Operations {
         if (settings.logging) {
             standardOutput.listenLogging { String m -> log.info(m) }
             standardError.listenLogging { String m -> log.error(m) }
+            if (settings.outputStream) { standardOutput.linkStream(settings.outputStream) }
+            if (settings.errorStream)  { standardError.linkStream(settings.errorStream) }
         }
 
         if (settings.interaction) {

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/BackgroundCommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/BackgroundCommandExecutionSpec.groovy
@@ -7,6 +7,8 @@ import org.codehaus.groovy.tools.Utilities
 import org.hidetake.groovy.ssh.api.session.BackgroundCommandException
 import org.hidetake.groovy.ssh.api.session.BadExitStatusException
 import org.hidetake.groovy.ssh.internal.operation.DefaultOperations
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 import org.slf4j.Logger
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -20,6 +22,9 @@ class BackgroundCommandExecutionSpec extends Specification {
     private static final NL = Utilities.eol()
 
     SshServer server
+
+    @Rule
+    TemporaryFolder temporaryFolder
 
     def setup() {
         server = SshServerMock.setUpLocalhostServer()
@@ -292,6 +297,91 @@ class BackgroundCommandExecutionSpec extends Specification {
 
         then:
         resultActual == 'some message'
+    }
+
+    @Unroll
+    def "execute should write to file if given: stdout=#stdout, stderr=#stderr"() {
+        given:
+        server.commandFactory = Mock(CommandFactory) {
+            1 * createCommand('somecommand') >> SshServerMock.command { SshServerMock.CommandContext c ->
+                c.outputStream.withWriter('UTF-8') { it << 'some message' }
+                c.errorStream.withWriter('UTF-8') { it << 'error' }
+                c.exitCallback.onExit(0)
+            }
+        }
+        server.start()
+
+        def logFile = temporaryFolder.newFile()
+
+        when:
+        logFile.withOutputStream { stream ->
+            ssh.run {
+                session(ssh.remotes.testServer) {
+                    def map = [:]
+                    if (stdout) { map.outputStream = stream }
+                    if (stderr) { map.errorStream = stream }
+                    executeBackground(map, 'somecommand')
+                }
+            }
+        }
+
+        then:
+        logFile.text == expectedLog
+
+        where:
+        stdout | stderr | expectedLog
+        false  | false  | ''
+        true   | false  | 'some message'
+        false  | true   | 'error'
+        true   | true   | 'some messageerror'
+    }
+
+    def "execute can write stdout/stderr to system.out"() {
+        given:
+        server.commandFactory = Mock(CommandFactory) {
+            1 * createCommand('somecommand') >> SshServerMock.command { SshServerMock.CommandContext c ->
+                c.outputStream.withWriter('UTF-8') { it << 'some message' }
+                c.errorStream.withWriter('UTF-8') { it << 'error' }
+                c.exitCallback.onExit(0)
+            }
+        }
+        server.start()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeBackground 'somecommand', outputStream: System.out, errorStream: System.err
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "execute should not write stdout/stderr to file if logging is off"() {
+        given:
+        server.commandFactory = Mock(CommandFactory) {
+            1 * createCommand('somecommand') >> SshServerMock.command { SshServerMock.CommandContext c ->
+                c.outputStream.withWriter('UTF-8') { it << 'some message' }
+                c.errorStream.withWriter('UTF-8') { it << 'error' }
+                c.exitCallback.onExit(0)
+            }
+        }
+        server.start()
+
+        def logFile = temporaryFolder.newFile()
+
+        when:
+        logFile.withOutputStream { stream ->
+            ssh.run {
+                session(ssh.remotes.testServer) {
+                    executeBackground 'somecommand', logging: false, outputStream: stream, errorStream: stream
+                }
+            }
+        }
+
+        then:
+        logFile.text == ''
     }
 
     private static commandWithExit(int status) {


### PR DESCRIPTION
This pull request adds following settings to execute, executeBackground and shell:
- `outputStream` - An output stream for logging standard output.
- `errorStream` - An output stream for logging standard error.
