### PR TITLE
Fix behavior of stream settings regardless of logging

### DIFF
--- a/src/main/groovy/org/hidetake/groovy/ssh/api/OperationSettings.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/api/OperationSettings.groovy
@@ -28,12 +28,12 @@ class OperationSettings extends Settings<OperationSettings> {
     Boolean logging
 
     /**
-     * An output stream to log standard output.
+     * An output stream to forward the standard output.
      */
     OutputStream outputStream
 
     /**
-     * An output stream to log standard error.
+     * An output stream to forward the standard error.
      */
     OutputStream errorStream
 

--- a/src/main/groovy/org/hidetake/groovy/ssh/internal/operation/DefaultOperations.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/internal/operation/DefaultOperations.groovy
@@ -43,7 +43,10 @@ class DefaultOperations implements Operations {
 
         if (settings.logging) {
             standardOutput.listenLogging { String m -> log.info(m) }
-            if (settings.outputStream) { standardOutput.linkStream(settings.outputStream) }
+        }
+
+        if (settings.outputStream) {
+            standardOutput.linkStream(settings.outputStream)
         }
 
         if (settings.interaction) {
@@ -85,8 +88,13 @@ class DefaultOperations implements Operations {
         if (settings.logging) {
             standardOutput.listenLogging { String m -> log.info(m) }
             standardError.listenLogging { String m -> log.error(m) }
-            if (settings.outputStream) { standardOutput.linkStream(settings.outputStream) }
-            if (settings.errorStream)  { standardError.linkStream(settings.errorStream) }
+        }
+
+        if (settings.outputStream) {
+            standardOutput.linkStream(settings.outputStream)
+        }
+        if (settings.errorStream) {
+            standardError.linkStream(settings.errorStream)
         }
 
         if (settings.interaction) {
@@ -136,8 +144,13 @@ class DefaultOperations implements Operations {
         if (settings.logging) {
             standardOutput.listenLogging { String m -> log.info(m) }
             standardError.listenLogging { String m -> log.error(m) }
-            if (settings.outputStream) { standardOutput.linkStream(settings.outputStream) }
-            if (settings.errorStream)  { standardError.linkStream(settings.errorStream) }
+        }
+
+        if (settings.outputStream) {
+            standardOutput.linkStream(settings.outputStream)
+        }
+        if (settings.errorStream) {
+            standardError.linkStream(settings.errorStream)
         }
 
         if (settings.interaction) {

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/BackgroundCommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/BackgroundCommandExecutionSpec.groovy
@@ -358,32 +358,6 @@ class BackgroundCommandExecutionSpec extends Specification {
         noExceptionThrown()
     }
 
-    def "execute should not write stdout/stderr to file if logging is off"() {
-        given:
-        server.commandFactory = Mock(CommandFactory) {
-            1 * createCommand('somecommand') >> SshServerMock.command { SshServerMock.CommandContext c ->
-                c.outputStream.withWriter('UTF-8') { it << 'some message' }
-                c.errorStream.withWriter('UTF-8') { it << 'error' }
-                c.exitCallback.onExit(0)
-            }
-        }
-        server.start()
-
-        def logFile = temporaryFolder.newFile()
-
-        when:
-        logFile.withOutputStream { stream ->
-            ssh.run {
-                session(ssh.remotes.testServer) {
-                    executeBackground 'somecommand', logging: false, outputStream: stream, errorStream: stream
-                }
-            }
-        }
-
-        then:
-        logFile.text == ''
-    }
-
     private static commandWithExit(int status) {
         SshServerMock.command { SshServerMock.CommandContext c ->
             c.exitCallback.onExit(status)

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/CommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/CommandExecutionSpec.groovy
@@ -306,30 +306,4 @@ class CommandExecutionSpec extends Specification {
         noExceptionThrown()
     }
 
-    def "execute should not write stdout/stderr to file if logging is off"() {
-        given:
-        server.commandFactory = Mock(CommandFactory) {
-            1 * createCommand('somecommand') >> SshServerMock.command { SshServerMock.CommandContext c ->
-                c.outputStream.withWriter('UTF-8') { it << 'some message' }
-                c.errorStream.withWriter('UTF-8') { it << 'error' }
-                c.exitCallback.onExit(0)
-            }
-        }
-        server.start()
-
-        def logFile = temporaryFolder.newFile()
-
-        when:
-        logFile.withOutputStream { stream ->
-            ssh.run {
-                session(ssh.remotes.testServer) {
-                    execute 'somecommand', logging: false, outputStream: stream, errorStream: stream
-                }
-            }
-        }
-
-        then:
-        logFile.text == ''
-    }
-
 }

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/ShellExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/ShellExecutionSpec.groovy
@@ -214,29 +214,4 @@ class ShellExecutionSpec extends Specification {
         noExceptionThrown()
     }
 
-    def "execute should not write stdout/stderr to file if logging is off"() {
-        given:
-        server.shellFactory = Mock(Factory) {
-            1 * create() >> SshServerMock.command { CommandContext c ->
-                c.outputStream.withWriter('UTF-8') { it << 'some message' }
-                c.exitCallback.onExit(0)
-            }
-        }
-        server.start()
-
-        def logFile = temporaryFolder.newFile()
-
-        when:
-        logFile.withOutputStream { stream ->
-            ssh.run {
-                session(ssh.remotes.testServer) {
-                    shell logging: false, outputStream: stream
-                }
-            }
-        }
-
-        then:
-        logFile.text == ''
-    }
-
 }


### PR DESCRIPTION
This pull request fixes behavior of `outputStream` and `errorStream` settings. They are intended for forwarding the stream to a file, not for logging. So they should work even if `logging` is set to false.

Following example saves the kernel log. This should work regardless of logging.

``` groovy
ssh.run {
  session(ssh.remotes.localhost) {
    new File('dmesg.log').withOutputStream { stream ->
      execute 'dmesg', outputStream: stream
    }
  }
}
```
