### PR TITLE
Improve logging setting to specify slf4j/stdout/none

### DIFF
--- a/src/main/groovy/org/hidetake/groovy/ssh/api/OperationSettings.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/api/OperationSettings.groovy
@@ -10,6 +10,26 @@ import org.hidetake.groovy.ssh.extension.SudoExecution
 @ToString
 class OperationSettings extends Settings<OperationSettings> {
     /**
+     * Logging methods.
+     */
+    static enum Logging {
+        /**
+         * Log is sent to SLF4J.
+         */
+        slf4j,
+
+        /**
+         * Log is sent to standard output or error.
+         */
+        stdout,
+
+        /**
+         * Logging is turned off.
+         */
+        none
+    }
+
+    /**
      * Dry-run flag.
      * If <code>true</code>, performs no action.
      */
@@ -22,10 +42,9 @@ class OperationSettings extends Settings<OperationSettings> {
     Boolean pty
 
     /**
-     * Logging flag.
-     * If <code>false</code>, performs no logging.
+     * A logging method of the remote command or shell.
      */
-    Boolean logging
+    Logging logging
 
     /**
      * An output stream to forward the standard output.
@@ -56,7 +75,7 @@ class OperationSettings extends Settings<OperationSettings> {
     static final DEFAULT = new OperationSettings(
             dryRun: false,
             pty: false,
-            logging: true,
+            logging: Logging.slf4j,
             encoding: 'UTF-8',
             extensions: [SudoExecution, SftpGet, SftpPut]
     )

--- a/src/main/groovy/org/hidetake/groovy/ssh/internal/operation/DefaultOperations.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/internal/operation/DefaultOperations.groovy
@@ -41,8 +41,13 @@ class DefaultOperations implements Operations {
         def standardOutput = new LineOutputStream(settings.encoding)
         channel.outputStream = standardOutput
 
-        if (settings.logging) {
-            standardOutput.listenLogging { String m -> log.info(m) }
+        switch (settings.logging) {
+            case OperationSettings.Logging.slf4j:
+                standardOutput.listenLogging { String m -> log.info(m) }
+                break
+            case OperationSettings.Logging.stdout:
+                standardOutput.listenLogging { String m -> System.out.println(m) }
+                break
         }
 
         if (settings.outputStream) {
@@ -85,9 +90,15 @@ class DefaultOperations implements Operations {
         channel.outputStream = standardOutput
         channel.errStream = standardError
 
-        if (settings.logging) {
-            standardOutput.listenLogging { String m -> log.info(m) }
-            standardError.listenLogging { String m -> log.error(m) }
+        switch (settings.logging) {
+            case OperationSettings.Logging.slf4j:
+                standardOutput.listenLogging { String m -> log.info(m) }
+                standardError.listenLogging  { String m -> log.error(m) }
+                break
+            case OperationSettings.Logging.stdout:
+                standardOutput.listenLogging { String m -> System.out.println(m) }
+                standardError.listenLogging  { String m -> System.err.println(m) }
+                break
         }
 
         if (settings.outputStream) {
@@ -141,9 +152,15 @@ class DefaultOperations implements Operations {
         channel.outputStream = standardOutput
         channel.errStream = standardError
 
-        if (settings.logging) {
-            standardOutput.listenLogging { String m -> log.info(m) }
-            standardError.listenLogging { String m -> log.error(m) }
+        switch (settings.logging) {
+            case OperationSettings.Logging.slf4j:
+                standardOutput.listenLogging { String m -> log.info(m) }
+                standardError.listenLogging  { String m -> log.error(m) }
+                break
+            case OperationSettings.Logging.stdout:
+                standardOutput.listenLogging { String m -> System.out.println(m) }
+                standardError.listenLogging  { String m -> System.err.println(m) }
+                break
         }
 
         if (settings.outputStream) {

--- a/src/test/groovy/org/hidetake/groovy/ssh/api/ServiceSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/api/ServiceSpec.groovy
@@ -36,6 +36,16 @@ class ServiceSpec extends Specification {
         ssh.settings.proxy == ssh.proxies.globalProxy
     }
 
+    def "logging setting can be set by a string"() {
+        when:
+        ssh.settings {
+            logging = 'stdout'
+        }
+
+        then:
+        ssh.settings.logging == OperationSettings.Logging.stdout
+    }
+
     @Unroll
     def "filter remotes by role: #roles"() {
         given:

--- a/src/test/groovy/org/hidetake/groovy/ssh/internal/session/DefaultSessionHandlerSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/internal/session/DefaultSessionHandlerSpec.groovy
@@ -31,11 +31,11 @@ class DefaultSessionHandlerSpec extends Specification {
     def "invoke a shell with options"() {
         when:
         defaultSessionHandler.with {
-            shell(logging: false)
+            shell(logging: 'none')
         }
 
         then:
-        1 * operations.shell(OperationSettings.DEFAULT + new OperationSettings(logging: false, dryRun: true))
+        1 * operations.shell(OperationSettings.DEFAULT + new OperationSettings(logging: 'none', dryRun: true))
     }
 
     def "execute a command"() {

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/CommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/CommandExecutionSpec.groovy
@@ -4,6 +4,7 @@ import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
 import org.apache.sshd.server.PasswordAuthenticator
 import org.codehaus.groovy.tools.Utilities
+import org.hidetake.groovy.ssh.api.OperationSettings
 import org.hidetake.groovy.ssh.api.session.BadExitStatusException
 import org.hidetake.groovy.ssh.internal.operation.DefaultOperations
 import org.junit.Rule
@@ -218,16 +219,21 @@ class CommandExecutionSpec extends Specification {
 
     @Unroll
     @ConfineMetaClassChanges(DefaultOperations)
-    def "toggle logging = #logging"() {
+    def "execute should write stdout/stderr to #logging"() {
         given:
-        def logger = Mock(Logger) {
-            isInfoEnabled() >> true
-        }
+        def out = System.out
+        def err = System.err
+        System.out = Mock(PrintStream)
+        System.err = Mock(PrintStream)
+
+        def logger = Mock(Logger)
+        logger.isInfoEnabled() >> true
         DefaultOperations.metaClass.static.getLog = { -> logger }
 
         server.commandFactory = Mock(CommandFactory) {
             1 * createCommand('somecommand') >> SshServerMock.command { SshServerMock.CommandContext c ->
                 c.outputStream.withWriter('UTF-8') { it << 'some message' }
+                c.errorStream.withWriter('UTF-8') { it << 'error' }
                 c.exitCallback.onExit(0)
             }
         }
@@ -236,15 +242,26 @@ class CommandExecutionSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                execute('somecommand', logging: logging)
+                execute 'somecommand', logging: logging
             }
         }
 
         then:
-        (logging ? 1 : 0) * logger.info('some message')
+        stdout * System.out.println('some message')
+        stdout * System.err.println('error')
+
+        slf4j * logger.info('some message')
+        slf4j * logger.error('error')
+
+        cleanup:
+        System.out = out
+        System.err = err
 
         where:
-        logging << [true, false]
+        logging                          | stdout | slf4j
+        OperationSettings.Logging.stdout | 1      | 0
+        OperationSettings.Logging.slf4j  | 0      | 1
+        OperationSettings.Logging.none   | 0      | 0
     }
 
     @Unroll

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/DryRunSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/DryRunSpec.groovy
@@ -42,7 +42,7 @@ class DryRunSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                shell(logging: false)
+                shell(logging: 'none')
             }
         }
 


### PR DESCRIPTION
This pull request adds logging methods of a remote command or shell.

Console log will be sent to standard output/error in following example.

``` groovy
ssh.settings {
  logging = 'stdout'
}
```
