### PR TITLE
Provide a standalone command line tool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '0.6'
+    id 'com.github.johnrengelman.shadow' version '1.1.1'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_7
@@ -12,18 +13,28 @@ repositories {
     jcenter()
 }
 
+configurations {
+    cliRuntime
+}
+
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.3.6'
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'com.jcraft:jsch:0.1.51'
-	compile 'com.jcraft:jsch.agentproxy.connector-factory:0.0.7'
-	compile 'com.jcraft:jsch.agentproxy.jsch:0.0.7'
-    testCompile('org.spockframework:spock-core:0.7-groovy-2.0')
+    compile 'com.jcraft:jsch.agentproxy.connector-factory:0.0.7'
+    compile 'com.jcraft:jsch.agentproxy.jsch:0.0.7'
+
+    testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
     testCompile 'cglib:cglib-nodep:3.1'
-    testRuntime 'org.objenesis:objenesis:2.1'
-    testRuntime 'ch.qos.logback:logback-classic:1.1.2'
     testCompile 'org.apache.sshd:sshd-core:0.12.0'
+
+    testRuntime 'ch.qos.logback:logback-classic:1.1.2'
+    testRuntime 'org.objenesis:objenesis:2.1'
     testRuntime 'org.bouncycastle:bcpkix-jdk15on:1.51'
+    testRuntime 'commons-cli:commons-cli:1.2'
+
+    cliRuntime 'ch.qos.logback:logback-classic:1.1.2'
+    cliRuntime 'commons-cli:commons-cli:1.2'
 }
 
 test {
@@ -69,6 +80,14 @@ task javadocJar(type: Jar, dependsOn: groovydoc) {
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
     classifier = 'sources'
+}
+
+shadowJar {
+    manifest {
+        attributes 'Main-Class': 'org.hidetake.groovy.ssh.Main'
+    }
+    configurations = [project.configurations.runtime, project.configurations.cliRuntime]
+    mergeServiceFiles()
 }
 
 publishing {

--- a/src/main/groovy/org/hidetake/groovy/ssh/Main.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/Main.groovy
@@ -1,0 +1,66 @@
+package org.hidetake.groovy.ssh
+
+import groovy.util.logging.Slf4j
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * CLI main class.
+ *
+ * @author Hidetake Iwata
+ */
+@Slf4j
+class Main {
+    static void main(String[] args) {
+        def cli = new CliBuilder(usage: '[option...] [-e script-text] [script-filename] [script-args...]')
+        cli.h longOpt: 'help',  'Shows this help message.'
+        cli.i longOpt: 'info',  'Set log level to info.'
+        cli.d longOpt: 'debug', 'Set log level to debug.'
+        cli.e args: 1,          'Specify a command line script.'
+
+        def options = cli.parse(args)
+        if (!options || options.h) {
+            cli.usage()
+        } else {
+            if (options.d) {
+                configureLogLevel('DEBUG')
+            } else if (options.i) {
+                configureLogLevel('INFO')
+            } else {
+                configureLogLevel('WARN')
+            }
+
+            if (options.e) {
+                Ssh.shell.run(options.e as String, 'script.groovy', options.arguments())
+            } else {
+                def extraArguments = options.arguments()
+                if (extraArguments.size() > 0) {
+                    if (extraArguments.head() == '-') {
+                        Ssh.shell.run(System.in.newReader(), 'script.groovy', extraArguments.tail())
+                    } else {
+                        Ssh.shell.run(new File(extraArguments.head()), extraArguments.tail())
+                    }
+                } else {
+                    Ssh.shell.run(System.in.newReader(), 'script.groovy')
+                }
+            }
+        }
+    }
+
+    /**
+     * Configure log level of Logback.
+     * This method should not fail if Logback is not loaded.
+     *
+     * @param level log level as a string
+     */
+    private static void configureLogLevel(String level) {
+        try {
+            def levelClass = Class.forName('ch.qos.logback.classic.Level')
+            def levelObject = levelClass.invokeMethod('toLevel', level)
+            def root = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)
+            root.setLevel(levelObject)
+        } catch (ClassNotFoundException e) {
+            log.info("Could not set log level to $level: ${e.localizedMessage}")
+        }
+    }
+}

--- a/src/main/groovy/org/hidetake/groovy/ssh/Ssh.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/Ssh.groovy
@@ -1,21 +1,35 @@
 package org.hidetake.groovy.ssh
 
+import groovy.transform.CompileStatic
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.customizers.ImportCustomizer
 import org.hidetake.groovy.ssh.api.Service
 import org.hidetake.groovy.ssh.internal.DefaultService
 
 /**
- * Groovy SSH.
+ * Entry point of Groovy SSH library.
  *
  * @author Hidetake Iwata
  */
+@CompileStatic
 class Ssh {
-    static final Service ssh
-
-    static Service createService() {
+    /**
+     * An implementation of {@link Service}.
+     */
+    @Lazy
+    static final Service ssh = {
         new DefaultService()
-    }
+    }()
 
-    static {
-        ssh = createService()
-    }
+    /**
+     * A {@link GroovyShell} object to run a Groovy script.
+     */
+    @Lazy
+    static final GroovyShell shell = {
+        def importCustomizer = new ImportCustomizer()
+        importCustomizer.addStaticImport(Ssh.class.name, 'ssh')
+        def configuration = new CompilerConfiguration()
+        configuration.addCompilationCustomizers(importCustomizer)
+        new GroovyShell(configuration)
+    }()
 }

--- a/src/test/groovy/org/hidetake/groovy/ssh/MainSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/MainSpec.groovy
@@ -1,0 +1,111 @@
+package org.hidetake.groovy.ssh
+
+import org.apache.sshd.SshServer
+import org.apache.sshd.server.CommandFactory
+import org.apache.sshd.server.PasswordAuthenticator
+import org.hidetake.groovy.ssh.internal.operation.DefaultOperations
+import org.hidetake.groovy.ssh.server.SshServerMock
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import org.slf4j.Logger
+import spock.lang.Specification
+import spock.util.mop.ConfineMetaClassChanges
+
+@ConfineMetaClassChanges(DefaultOperations)
+class MainSpec extends Specification {
+
+    SshServer server
+
+    Logger logger
+
+    String script
+
+    @Rule
+    TemporaryFolder temporaryFolder
+
+    def setup() {
+        server = SshServerMock.setUpLocalhostServer()
+        server.passwordAuthenticator = Mock(PasswordAuthenticator) {
+            _ * authenticate('someuser', 'somepassword', _) >> true
+        }
+        server.commandFactory = Mock(CommandFactory) {
+            1 * createCommand('somecommand') >> SshServerMock.command { SshServerMock.CommandContext c ->
+                c.outputStream.withWriter('UTF-8') { it << 'some message' }
+                c.errorStream.withWriter('UTF-8') { it << 'error' }
+                c.exitCallback.onExit(0)
+            }
+        }
+        server.start()
+
+        def hostKey = MainSpec.getResourceAsStream('/hostkey.pub').text
+        def knownHostsFile = temporaryFolder.newFile() << "[localhost]:${server.port} ${hostKey}"
+        script = "ssh.run {" +
+                "session(host: 'localhost'," +
+                " port: ${server.port}," +
+                " knownHosts: new File('${knownHostsFile.path}')," +
+                " user: 'someuser'," +
+                " password: 'somepassword')" +
+                "{ execute('somecommand') }" +
+                "}"
+
+        logger = Mock(Logger)
+        logger.isInfoEnabled() >> true
+        logger.isErrorEnabled() >> true
+        DefaultOperations.metaClass.static.getLog = { -> logger }
+    }
+
+    def "main should evaluate a script line if -e is given"() {
+        when:
+        Main.main '-d', '-e', script
+
+        then:
+        1 * logger.info('some message')
+        1 * logger.error('error')
+    }
+
+    def "main should read script from standard input if no arg is given"() {
+        given:
+        def stdin = System.in
+        System.in = new ByteArrayInputStream(script.bytes)
+
+        when:
+        Main.main '-d'
+
+        then:
+        1 * logger.info('some message')
+        1 * logger.error('error')
+
+        cleanup:
+        System.in = stdin
+    }
+
+    def "main should read script from standard input if - is given"() {
+        given:
+        def stdin = System.in
+        System.in = new ByteArrayInputStream(script.bytes)
+
+        when:
+        Main.main '-d', '-'
+
+        then:
+        1 * logger.info('some message')
+        1 * logger.error('error')
+
+        cleanup:
+        System.in = stdin
+    }
+
+    def "main should read script from a file is path is given"() {
+        given:
+        def scriptFile = temporaryFolder.newFile()
+        scriptFile << script
+
+        when:
+        Main.main '-d', scriptFile.path
+
+        then:
+        1 * logger.info('some message')
+        1 * logger.error('error')
+    }
+
+}


### PR DESCRIPTION
This pull request provides all-in-one JAR as a command line tool.

We can run a Groovy script by `java -jar groovy-ssh-x.y.z-all.jar` as follows:

```
% java -jar groovy-ssh-0.1.4-all.jar -i -e 'ssh.run { session(host: "localhost", user: "example", identity: new File("~/.ssh/id_rsa")) { execute("uname -a") } }'
21:19:01.470 [main] INFO  o.h.g.s.i.c.DefaultConnectionManager - Established a session to Remote localhost [localhost:22] via localhost:22
21:19:01.561 [main] INFO  o.h.g.s.i.s.DefaultSessionHandler - Execute a command (uname -a)
21:19:01.600 [main] INFO  o.h.g.s.i.o.DefaultOperations - Channel #0 has been opened
21:19:01.653 [Connect thread localhost session] INFO  o.h.g.s.i.o.DefaultOperations - Darwin example.local 14.0.0 Darwin Kernel Version 14.0.0: Fri Sep 19 00:26:44 PDT 2014; root:xnu-2782.1.97~2/RELEASE_X86_64 x86_64
21:19:01.703 [main] INFO  o.h.g.s.i.o.DefaultOperations - Channel #0 has been closed with exit status 0
```
