### PR TITLE
Change entry point of API for stateless design

### DIFF
--- a/src/main/groovy/org/hidetake/groovy/ssh/Main.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/Main.groovy
@@ -31,17 +31,17 @@ class Main {
             }
 
             if (options.e) {
-                Ssh.shell.run(options.e as String, 'script.groovy', options.arguments())
+                Ssh.newShell().run(options.e as String, 'script.groovy', options.arguments())
             } else {
                 def extraArguments = options.arguments()
                 if (extraArguments.size() > 0) {
                     if (extraArguments.head() == '-') {
-                        Ssh.shell.run(System.in.newReader(), 'script.groovy', extraArguments.tail())
+                        Ssh.newShell().run(System.in.newReader(), 'script.groovy', extraArguments.tail())
                     } else {
-                        Ssh.shell.run(new File(extraArguments.head()), extraArguments.tail())
+                        Ssh.newShell().run(new File(extraArguments.head()), extraArguments.tail())
                     }
                 } else {
-                    Ssh.shell.run(System.in.newReader(), 'script.groovy')
+                    Ssh.newShell().run(System.in.newReader(), 'script.groovy')
                 }
             }
         }

--- a/src/main/groovy/org/hidetake/groovy/ssh/Ssh.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/Ssh.groovy
@@ -14,22 +14,18 @@ import org.hidetake.groovy.ssh.internal.DefaultService
 @CompileStatic
 class Ssh {
     /**
-     * An implementation of {@link Service}.
+     * Create an implementation of {@link Service}.
      */
-    @Lazy
-    static final Service ssh = {
+    static Service newService() {
         new DefaultService()
-    }()
+    }
 
     /**
-     * A {@link GroovyShell} object to run a Groovy script.
+     * Create a {@link GroovyShell} object to run a Groovy script.
      */
-    @Lazy
-    static final GroovyShell shell = {
-        def importCustomizer = new ImportCustomizer()
-        importCustomizer.addStaticImport(Ssh.class.name, 'ssh')
-        def configuration = new CompilerConfiguration()
-        configuration.addCompilationCustomizers(importCustomizer)
-        new GroovyShell(configuration)
-    }()
+    static GroovyShell newShell() {
+        def binding = new Binding()
+        binding.variables.ssh = newService()
+        new GroovyShell(binding)
+    }
 }

--- a/src/main/groovy/org/hidetake/groovy/ssh/api/CompositeSettings.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/api/CompositeSettings.groovy
@@ -29,9 +29,4 @@ class CompositeSettings extends Settings<CompositeSettings> {
                 operationSettings: operationSettings + right.operationSettings
         )
     }
-
-    void reset() {
-        connectionSettings = new ConnectionSettings()
-        operationSettings = new OperationSettings()
-    }
 }

--- a/src/test/groovy/org/hidetake/groovy/ssh/api/ServiceSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/api/ServiceSpec.groovy
@@ -1,18 +1,17 @@
 package org.hidetake.groovy.ssh.api
 
+import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.internal.DefaultRunHandler
 import spock.lang.Specification
 import spock.lang.Unroll
 import spock.util.mop.ConfineMetaClassChanges
 
-import static org.hidetake.groovy.ssh.Ssh.ssh
-
 class ServiceSpec extends Specification {
 
-    def cleanup() {
-        ssh.remotes.clear()
-        ssh.proxies.clear()
-        ssh.settings.reset()
+    Service ssh
+
+    def setup() {
+        ssh = Ssh.newService()
     }
 
     def "global settings can be set"() {
@@ -144,7 +143,7 @@ class ServiceSpec extends Specification {
         err.message.contains("closure")
     }
 
-    private static void configureFixture() {
+    private void configureFixture() {
         ssh.settings {
             knownHosts = allowAnyHosts
         }

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/AuthenticationSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/AuthenticationSpec.groovy
@@ -3,28 +3,28 @@ package org.hidetake.groovy.ssh.server
 import com.jcraft.jsch.JSchException
 import org.apache.sshd.SshServer
 import org.apache.sshd.server.*
+import org.hidetake.groovy.ssh.Ssh
+import org.hidetake.groovy.ssh.api.Service
 import spock.lang.Specification
 
 import java.security.PublicKey
-
-import static org.hidetake.groovy.ssh.Ssh.ssh
 
 @org.junit.experimental.categories.Category(ServerIntegrationTest)
 class AuthenticationSpec extends Specification {
 
     SshServer server
 
+    Service ssh
+
     def setup() {
         server = SshServerMock.setUpLocalhostServer()
+        ssh = Ssh.newService()
         ssh.settings {
             knownHosts = allowAnyHosts
         }
     }
 
     def cleanup() {
-        ssh.remotes.clear()
-        ssh.proxies.clear()
-        ssh.settings.reset()
         server.stop(true)
     }
 

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/BackgroundCommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/BackgroundCommandExecutionSpec.groovy
@@ -4,7 +4,9 @@ import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
 import org.apache.sshd.server.PasswordAuthenticator
 import org.codehaus.groovy.tools.Utilities
+import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.api.OperationSettings
+import org.hidetake.groovy.ssh.api.Service
 import org.hidetake.groovy.ssh.api.session.BackgroundCommandException
 import org.hidetake.groovy.ssh.api.session.BadExitStatusException
 import org.hidetake.groovy.ssh.internal.operation.DefaultOperations
@@ -15,14 +17,14 @@ import spock.lang.Specification
 import spock.lang.Unroll
 import spock.util.mop.ConfineMetaClassChanges
 
-import static org.hidetake.groovy.ssh.Ssh.ssh
-
 @org.junit.experimental.categories.Category(ServerIntegrationTest)
 class BackgroundCommandExecutionSpec extends Specification {
 
     private static final NL = Utilities.eol()
 
     SshServer server
+
+    Service ssh
 
     @Rule
     TemporaryFolder temporaryFolder
@@ -33,6 +35,7 @@ class BackgroundCommandExecutionSpec extends Specification {
             _ * authenticate('someuser', 'somepassword', _) >> true
         }
 
+        ssh = Ssh.newService()
         ssh.settings {
             knownHosts = allowAnyHosts
         }
@@ -47,9 +50,6 @@ class BackgroundCommandExecutionSpec extends Specification {
     }
 
     def cleanup() {
-        ssh.remotes.clear()
-        ssh.proxies.clear()
-        ssh.settings.reset()
         server.stop(true)
     }
 

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/CommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/CommandExecutionSpec.groovy
@@ -4,7 +4,9 @@ import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
 import org.apache.sshd.server.PasswordAuthenticator
 import org.codehaus.groovy.tools.Utilities
+import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.api.OperationSettings
+import org.hidetake.groovy.ssh.api.Service
 import org.hidetake.groovy.ssh.api.session.BadExitStatusException
 import org.hidetake.groovy.ssh.internal.operation.DefaultOperations
 import org.junit.Rule
@@ -14,14 +16,14 @@ import spock.lang.Specification
 import spock.lang.Unroll
 import spock.util.mop.ConfineMetaClassChanges
 
-import static org.hidetake.groovy.ssh.Ssh.ssh
-
 @org.junit.experimental.categories.Category(ServerIntegrationTest)
 class CommandExecutionSpec extends Specification {
 
     private static final NL = Utilities.eol()
 
     SshServer server
+
+    Service ssh
 
     @Rule
     TemporaryFolder temporaryFolder
@@ -32,6 +34,7 @@ class CommandExecutionSpec extends Specification {
             _ * authenticate('someuser', 'somepassword', _) >> true
         }
 
+        ssh = Ssh.newService()
         ssh.settings {
             knownHosts = allowAnyHosts
         }
@@ -46,9 +49,6 @@ class CommandExecutionSpec extends Specification {
     }
 
     def cleanup() {
-        ssh.remotes.clear()
-        ssh.proxies.clear()
-        ssh.settings.reset()
         server.stop(true)
     }
 

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/DryRunSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/DryRunSpec.groovy
@@ -1,12 +1,15 @@
 package org.hidetake.groovy.ssh.server
 
+import org.hidetake.groovy.ssh.Ssh
+import org.hidetake.groovy.ssh.api.Service
 import spock.lang.Specification
-
-import static org.hidetake.groovy.ssh.Ssh.ssh
 
 class DryRunSpec extends Specification {
 
+    Service ssh
+
     def setup() {
+        ssh = Ssh.newService()
         ssh.settings {
             knownHosts = allowAnyHosts
             dryRun = true
@@ -17,12 +20,6 @@ class DryRunSpec extends Specification {
                 user = 'user'
             }
         }
-    }
-
-    def cleanup() {
-        ssh.remotes.clear()
-        ssh.proxies.clear()
-        ssh.settings.reset()
     }
 
 

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/FileTransferSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/FileTransferSpec.groovy
@@ -3,13 +3,13 @@ package org.hidetake.groovy.ssh.server
 import org.apache.sshd.SshServer
 import org.apache.sshd.server.PasswordAuthenticator
 import org.apache.sshd.server.sftp.SftpSubsystem
+import org.hidetake.groovy.ssh.Ssh
+import org.hidetake.groovy.ssh.api.Service
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.util.mop.Use
-
-import static org.hidetake.groovy.ssh.Ssh.ssh
 
 @org.junit.experimental.categories.Category(ServerIntegrationTest)
 @Use(FileDivCategory)
@@ -17,6 +17,8 @@ class FileTransferSpec extends Specification {
 
     @Shared
     SshServer server
+
+    Service ssh
 
     @Rule
     TemporaryFolder temporaryFolder
@@ -31,14 +33,12 @@ class FileTransferSpec extends Specification {
     }
 
     def cleanupSpec() {
-        ssh.remotes.clear()
-        ssh.proxies.clear()
-        ssh.settings.reset()
         server.stop(true)
     }
 
 
     def setup() {
+        ssh = Ssh.newService()
         ssh.settings {
             knownHosts = allowAnyHosts
         }

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/HostKeyCheckingSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/HostKeyCheckingSpec.groovy
@@ -5,6 +5,8 @@ import groovy.util.logging.Slf4j
 import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
 import org.apache.sshd.server.PasswordAuthenticator
+import org.hidetake.groovy.ssh.Ssh
+import org.hidetake.groovy.ssh.api.Service
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -13,13 +15,14 @@ import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
 import static org.hidetake.groovy.ssh.server.SshServerMock.commandWithExit
-import static org.hidetake.groovy.ssh.Ssh.ssh
 
 @org.junit.experimental.categories.Category(ServerIntegrationTest)
 @Slf4j
 class HostKeyCheckingSpec extends Specification {
 
     SshServer server
+
+    Service ssh
 
     @Rule
     TemporaryFolder temporaryFolder
@@ -30,6 +33,7 @@ class HostKeyCheckingSpec extends Specification {
         server.commandFactory = Mock(CommandFactory)
         server.start()
 
+        ssh = Ssh.newService()
         ssh.remotes {
             testServer {
                 host = server.host

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/PortForwardingSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/PortForwardingSpec.groovy
@@ -5,10 +5,10 @@ import org.apache.sshd.common.Factory
 import org.apache.sshd.common.ForwardingFilter
 import org.apache.sshd.common.SshdSocketAddress
 import org.apache.sshd.server.PasswordAuthenticator
+import org.hidetake.groovy.ssh.Ssh
+import org.hidetake.groovy.ssh.api.Service
 import org.hidetake.groovy.ssh.server.SshServerMock.CommandContext
 import spock.lang.Specification
-
-import static org.hidetake.groovy.ssh.Ssh.ssh
 
 @org.junit.experimental.categories.Category(ServerIntegrationTest)
 class PortForwardingSpec extends Specification {
@@ -17,11 +17,14 @@ class PortForwardingSpec extends Specification {
     SshServer gateway1Server
     SshServer gateway2Server
 
+    Service ssh
+
     def setup() {
         targetServer = setupServer('target')
         gateway1Server = setupServer('gateway1')
         gateway2Server = setupServer('gateway2')
 
+        ssh = Ssh.newService()
         ssh.settings {
             knownHosts = allowAnyHosts
         }
@@ -38,9 +41,6 @@ class PortForwardingSpec extends Specification {
     }
 
     def cleanup() {
-        ssh.remotes.clear()
-        ssh.proxies.clear()
-        ssh.settings.reset()
         targetServer.stop(true)
         gateway1Server.stop(true)
         gateway2Server.stop(true)

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/ShellExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/ShellExecutionSpec.groovy
@@ -3,7 +3,9 @@ package org.hidetake.groovy.ssh.server
 import org.apache.sshd.SshServer
 import org.apache.sshd.common.Factory
 import org.apache.sshd.server.PasswordAuthenticator
+import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.api.OperationSettings
+import org.hidetake.groovy.ssh.api.Service
 import org.hidetake.groovy.ssh.api.session.BadExitStatusException
 import org.hidetake.groovy.ssh.internal.operation.DefaultOperations
 import org.hidetake.groovy.ssh.server.SshServerMock.CommandContext
@@ -14,12 +16,12 @@ import spock.lang.Specification
 import spock.lang.Unroll
 import spock.util.mop.ConfineMetaClassChanges
 
-import static org.hidetake.groovy.ssh.Ssh.ssh
-
 @org.junit.experimental.categories.Category(ServerIntegrationTest)
 class ShellExecutionSpec extends Specification {
 
     SshServer server
+
+    Service ssh
 
     @Rule
     TemporaryFolder temporaryFolder
@@ -30,6 +32,7 @@ class ShellExecutionSpec extends Specification {
             _ * authenticate('someuser', 'somepassword', _) >> true
         }
 
+        ssh = Ssh.newService()
         ssh.settings {
             knownHosts = allowAnyHosts
         }
@@ -44,9 +47,6 @@ class ShellExecutionSpec extends Specification {
     }
 
     def cleanup() {
-        ssh.remotes.clear()
-        ssh.proxies.clear()
-        ssh.settings.reset()
         server.stop(true)
     }
 

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/SudoCommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/SudoCommandExecutionSpec.groovy
@@ -4,6 +4,8 @@ import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
 import org.apache.sshd.server.PasswordAuthenticator
 import org.codehaus.groovy.tools.Utilities
+import org.hidetake.groovy.ssh.Ssh
+import org.hidetake.groovy.ssh.api.Service
 import org.hidetake.groovy.ssh.api.session.BadExitStatusException
 import org.hidetake.groovy.ssh.internal.operation.DefaultOperations
 import org.hidetake.groovy.ssh.server.SshServerMock.CommandContext
@@ -12,8 +14,6 @@ import spock.lang.Specification
 import spock.lang.Unroll
 import spock.util.mop.ConfineMetaClassChanges
 
-import static org.hidetake.groovy.ssh.Ssh.ssh
-
 @org.junit.experimental.categories.Category(ServerIntegrationTest)
 class SudoCommandExecutionSpec extends Specification {
 
@@ -21,12 +21,15 @@ class SudoCommandExecutionSpec extends Specification {
 
     SshServer server
 
+    Service ssh
+
     def setup() {
         server = SshServerMock.setUpLocalhostServer()
         server.passwordAuthenticator = Mock(PasswordAuthenticator) {
             _ * authenticate('someuser', 'somepassword', _) >> true
         }
 
+        ssh = Ssh.newService()
         ssh.settings {
             knownHosts = allowAnyHosts
         }
@@ -41,9 +44,6 @@ class SudoCommandExecutionSpec extends Specification {
     }
 
     def cleanup() {
-        ssh.remotes.clear()
-        ssh.proxies.clear()
-        ssh.settings.reset()
         server.stop(true)
     }
 


### PR DESCRIPTION
Since the entry point (org.hidetake.groovy.ssh.Ssh) has static instance of service, it may cause state problem. So it is better to create an new instance for each usage not reuse an instance.

This pull request replaces static properties with instance creation methods as follows:
- `org.hidetake.groovy.ssh.Ssh.ssh` -> `org.hidetake.groovy.ssh.Ssh.newService()`
- `org.hidetake.groovy.ssh.Ssh.shell` -> `org.hidetake.groovy.ssh.Ssh.newShell()`
