### PR TITLE
Add session() with var args of remotes and a closure

### DIFF
--- a/src/main/groovy/org/hidetake/groovy/ssh/api/RunHandler.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/api/RunHandler.groovy
@@ -39,4 +39,13 @@ interface RunHandler {
      * @param closure closure for {@link org.hidetake.groovy.ssh.api.session.SessionHandler}
      */
     void session(Map remoteProperties, @DelegatesTo(SessionHandler) Closure closure)
+
+    /**
+     * Add sessions.
+     * This is a last resort method and allows only below arguments.
+     *
+     * @param args elements except last must be {@link Remote}s and last must be a closure
+     * @throws IllegalArgumentException if wrong arguments are given.
+     */
+    void session(Object[] args)
 }

--- a/src/main/groovy/org/hidetake/groovy/ssh/internal/DefaultRunHandler.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/internal/DefaultRunHandler.groovy
@@ -1,5 +1,6 @@
 package org.hidetake.groovy.ssh.internal
 
+import groovy.transform.CompileStatic
 import org.hidetake.groovy.ssh.api.CompositeSettings
 import org.hidetake.groovy.ssh.api.Remote
 import org.hidetake.groovy.ssh.api.RunHandler
@@ -50,6 +51,21 @@ class DefaultRunHandler implements RunHandler {
         def remote = new Remote(remoteProperties.host as String)
         remoteProperties.each { k, v -> remote[k as String] = v }
         session(remote, closure)
+    }
+
+    @Override
+    void session(Object[] args) {
+        if (args.last() instanceof Closure) {
+            def remotes = args.take(args.length - 1)
+            def closure = args.last()
+            remotes.each { remote -> session(remote as Remote, closure as Closure) }
+        } else {
+            throw new IllegalArgumentException('''session() allows following arguments:
+session(remote) {}
+session(remote1, remote2, ...) {}
+session([remote1, remote2, ...]) {}
+session(host: 'myHost', user: 'myUser', ...) {}''')
+        }
     }
 
     Object run(CompositeSettings globalSettings) {

--- a/src/test/groovy/org/hidetake/groovy/ssh/internal/DefaultRunHandlerSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/internal/DefaultRunHandlerSpec.groovy
@@ -68,7 +68,7 @@ class DefaultRunHandlerSpec extends Specification {
 
 
 
-    def "add session for multiple remotes"() {
+    def "add session for multiple remotes by list"() {
         given:
         def remote1 = new Remote('myRemote1')
         remote1.user = 'myUser1'
@@ -76,10 +76,29 @@ class DefaultRunHandlerSpec extends Specification {
         def remote2 = new Remote('myRemote2')
         remote2.user = 'myUser2'
         remote2.host = 'myHost2'
-        def closure = { assert false }
 
         when:
-        runHandler.session([remote1, remote2], closure)
+        runHandler.session([remote1, remote2]) {
+            assert false
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "add session for multiple remotes by var args"() {
+        given:
+        def remote1 = new Remote('myRemote1')
+        remote1.user = 'myUser1'
+        remote1.host = 'myHost1'
+        def remote2 = new Remote('myRemote2')
+        remote2.user = 'myUser2'
+        remote2.host = 'myHost2'
+
+        when:
+        runHandler.session(remote1, remote2) {
+            assert false
+        }
 
         then:
         noExceptionThrown()
@@ -156,6 +175,21 @@ class DefaultRunHandlerSpec extends Specification {
         then:
         AssertionError ex = thrown()
         ex.message.contains("host")
+    }
+
+
+    def "session() with wrong arguments causes an error"() {
+        given:
+        def remote = new Remote('myRemote')
+        remote.user = 'myUser'
+        remote.host = 'myHost'
+
+        when:
+        runHandler.session(remote)
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message.contains('arguments')
     }
 
 


### PR DESCRIPTION
See #17. This pull request allows `session()` accepts var args as follows:

``` groovy
ssh.run {
  session(remote1, remote2, remote3) {
    //...
  }
}
```
