### PR TITLE
Prepend host name to console log

### DIFF
--- a/src/main/groovy/org/hidetake/groovy/ssh/internal/operation/DefaultOperations.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/internal/operation/DefaultOperations.groovy
@@ -43,7 +43,7 @@ class DefaultOperations implements Operations {
 
         switch (settings.logging) {
             case OperationSettings.Logging.slf4j:
-                standardOutput.listenLogging { String m -> log.info(m) }
+                standardOutput.listenLogging { String m -> log.info("${remote.name}|$m") }
                 break
             case OperationSettings.Logging.stdout:
                 standardOutput.listenLogging { String m -> System.out.println(m) }
@@ -92,8 +92,8 @@ class DefaultOperations implements Operations {
 
         switch (settings.logging) {
             case OperationSettings.Logging.slf4j:
-                standardOutput.listenLogging { String m -> log.info(m) }
-                standardError.listenLogging  { String m -> log.error(m) }
+                standardOutput.listenLogging { String m -> log.info("${remote.name}|$m") }
+                standardError.listenLogging  { String m -> log.error("${remote.name}|$m") }
                 break
             case OperationSettings.Logging.stdout:
                 standardOutput.listenLogging { String m -> System.out.println(m) }
@@ -154,8 +154,8 @@ class DefaultOperations implements Operations {
 
         switch (settings.logging) {
             case OperationSettings.Logging.slf4j:
-                standardOutput.listenLogging { String m -> log.info(m) }
-                standardError.listenLogging  { String m -> log.error(m) }
+                standardOutput.listenLogging { String m -> log.info("${remote.name}|$m") }
+                standardError.listenLogging  { String m -> log.error("${remote.name}|$m") }
                 break
             case OperationSettings.Logging.stdout:
                 standardOutput.listenLogging { String m -> System.out.println(m) }

--- a/src/test/groovy/org/hidetake/groovy/ssh/MainSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/MainSpec.groovy
@@ -61,8 +61,8 @@ class MainSpec extends Specification {
         Main.main '-e', script
 
         then:
-        1 * logger.info('some message')
-        1 * logger.error('error')
+        1 * logger.info ('localhost|some message')
+        1 * logger.error('localhost|error')
     }
 
     def "main should show usage if no arg is given"() {
@@ -90,8 +90,8 @@ class MainSpec extends Specification {
         Main.main '--stdin'
 
         then:
-        1 * logger.info('some message')
-        1 * logger.error('error')
+        1 * logger.info ('localhost|some message')
+        1 * logger.error('localhost|error')
 
         cleanup:
         System.in = stdin
@@ -106,8 +106,8 @@ class MainSpec extends Specification {
         Main.main scriptFile.path
 
         then:
-        1 * logger.info('some message')
-        1 * logger.error('error')
+        1 * logger.info ('localhost|some message')
+        1 * logger.error('localhost|error')
     }
 
     def "default log level should be INFO"() {

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/BackgroundCommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/BackgroundCommandExecutionSpec.groovy
@@ -224,7 +224,7 @@ class BackgroundCommandExecutionSpec extends Specification {
 
         then:
         logMessages.each {
-            1 * logger.info(it)
+            1 * logger.info("testServer|$it")
         }
 
         where:
@@ -268,8 +268,8 @@ class BackgroundCommandExecutionSpec extends Specification {
         stdout * System.out.println('some message')
         stdout * System.err.println('error')
 
-        slf4j * logger.info('some message')
-        slf4j * logger.error('error')
+        slf4j * logger.info ('testServer|some message')
+        slf4j * logger.error('testServer|error')
 
         cleanup:
         System.out = out

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/CommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/CommandExecutionSpec.groovy
@@ -206,7 +206,7 @@ class CommandExecutionSpec extends Specification {
 
         then:
         logMessages.each {
-            1 * logger.info(it)
+            1 * logger.info("testServer|$it")
         }
 
         where:
@@ -250,8 +250,8 @@ class CommandExecutionSpec extends Specification {
         stdout * System.out.println('some message')
         stdout * System.err.println('error')
 
-        slf4j * logger.info('some message')
-        slf4j * logger.error('error')
+        slf4j * logger.info ('testServer|some message')
+        slf4j * logger.error('testServer|error')
 
         cleanup:
         System.out = out

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/ShellExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/ShellExecutionSpec.groovy
@@ -118,7 +118,9 @@ class ShellExecutionSpec extends Specification {
         }
 
         then:
-        logMessages.each { 1 * logger.info(it) }
+        logMessages.each {
+            1 * logger.info("testServer|$it")
+        }
 
         where:
         description            | outputValue                  | logMessages
@@ -156,7 +158,7 @@ class ShellExecutionSpec extends Specification {
 
         then:
         stdout * System.out.println('some message')
-        slf4j * logger.info('some message')
+        slf4j * logger.info('testServer|some message')
 
         cleanup:
         System.out = out

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/SudoCommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/SudoCommandExecutionSpec.groovy
@@ -304,7 +304,7 @@ class SudoCommandExecutionSpec extends Specification {
 
         then:
         logMessages.each {
-            1 * logger.info(it)
+            1 * logger.info("testServer|$it")
         }
 
         where:


### PR DESCRIPTION
This pull request prepends a host name to the console log. It allows that a user can determine the host which sends a log message.
