### PR TITLE
Port forwarding support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
     testCompile 'cglib:cglib-nodep:3.1'
     testCompile 'org.apache.sshd:sshd-core:0.12.0'
+    testCompile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
 
     testRuntime 'ch.qos.logback:logback-classic:1.1.2'
     testRuntime 'org.objenesis:objenesis:2.1'

--- a/src/main/groovy/org/hidetake/groovy/ssh/connection/Connection.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/connection/Connection.groovy
@@ -6,8 +6,10 @@ import com.jcraft.jsch.ChannelSftp
 import com.jcraft.jsch.ChannelShell
 import com.jcraft.jsch.Session
 import groovy.util.logging.Slf4j
+import org.hidetake.groovy.ssh.extension.settings.LocalPortForwardSettings
 import org.hidetake.groovy.ssh.core.settings.OperationSettings
 import org.hidetake.groovy.ssh.core.Remote
+import org.hidetake.groovy.ssh.extension.settings.RemotePortForwardSettings
 import org.hidetake.groovy.ssh.session.BackgroundCommandException
 import org.hidetake.groovy.ssh.session.BadExitStatusException
 
@@ -67,6 +69,25 @@ class Connection {
         def channel = session.openChannel('sftp') as ChannelSftp
         channels.add(channel)
         channel
+    }
+
+    /**
+     * Set up local port forwarding.
+     *
+     * @param settings
+     * @return local port
+     */
+    int forwardLocalPort(LocalPortForwardSettings settings) {
+        session.setPortForwardingL(settings.bind, settings.port, settings.host, settings.hostPort)
+    }
+
+    /**
+     * Set up remote port forwarding.
+     *
+     * @param settings
+     */
+    void forwardRemotePort(RemotePortForwardSettings settings) {
+        session.setPortForwardingR(settings.bind, settings.port, settings.host, settings.hostPort)
     }
 
     /**

--- a/src/main/groovy/org/hidetake/groovy/ssh/extension/CoreExtensions.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/extension/CoreExtensions.groovy
@@ -1,4 +1,4 @@
 package org.hidetake.groovy.ssh.extension
 
-trait CoreExtensions implements Command, BackgroundCommand, Shell, SudoExecution, SftpGet, SftpPut {
+trait CoreExtensions implements Command, BackgroundCommand, Shell, SudoExecution, SftpGet, SftpPut, PortForward {
 }

--- a/src/main/groovy/org/hidetake/groovy/ssh/extension/PortForward.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/extension/PortForward.groovy
@@ -1,0 +1,40 @@
+package org.hidetake.groovy.ssh.extension
+
+import org.hidetake.groovy.ssh.extension.settings.LocalPortForwardSettings
+import org.hidetake.groovy.ssh.extension.settings.RemotePortForwardSettings
+import org.hidetake.groovy.ssh.session.SessionExtension
+
+/**
+ * An extension class of port forwarding.
+ *
+ * @author Hidetake Iwata
+ */
+trait PortForward implements SessionExtension {
+
+    /**
+     * Forwards local port to remote port.
+     *
+     * @param settings {@see LocalPortForwardingSettings}
+     * @return local port
+     */
+    int forwardLocalPort(HashMap settings) {
+        assert settings != null, 'settings must not be null'
+        def merged = LocalPortForwardSettings.DEFAULT + new LocalPortForwardSettings(settings)
+        assert merged.hostPort, 'remote port must be given'
+        operations.forwardLocalPort(merged)
+    }
+
+    /**
+     * Forwards remote port to local port.
+     *
+     * @param settings {@see RemotePortForwardingSettings}
+     */
+    void forwardRemotePort(HashMap settings) {
+        assert settings != null, 'settings must not be null'
+        def merged = RemotePortForwardSettings.DEFAULT + new RemotePortForwardSettings(settings)
+        assert merged.hostPort, 'local port must be given'
+        assert merged.port, 'remote port must be given'
+        operations.forwardRemotePort(merged)
+    }
+
+}

--- a/src/main/groovy/org/hidetake/groovy/ssh/extension/settings/LocalPortForwardSettings.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/extension/settings/LocalPortForwardSettings.groovy
@@ -1,0 +1,52 @@
+package org.hidetake.groovy.ssh.extension.settings
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import org.hidetake.groovy.ssh.core.settings.Settings
+
+import static org.hidetake.groovy.ssh.util.Utility.findNotNull
+
+/**
+ * Settings for the local port forwarding.
+ *
+ * @author Hidetake Iwata
+ */
+@EqualsAndHashCode
+@ToString
+class LocalPortForwardSettings implements Settings<LocalPortForwardSettings> {
+    /**
+     * Local port to bind. Defaults to 0 (allocate free port).
+     */
+    Integer port
+
+    /**
+     * Local host to bind. Defaults to localhost.
+     */
+    String bind
+
+    /**
+     * Remote port to connect. (Mandatory)
+     */
+    Integer hostPort
+
+    /**
+     * Remote host to connect. Default to localhost of the remote host.
+     */
+    String host
+
+    static final DEFAULT = new LocalPortForwardSettings(
+            port: 0,
+            bind: '127.0.0.1',
+            host: '127.0.0.1',
+    )
+
+    @Override
+    LocalPortForwardSettings plus(LocalPortForwardSettings right) {
+        new LocalPortForwardSettings(
+                port: findNotNull(right.port, port),
+                bind: findNotNull(right.bind, bind),
+                hostPort: findNotNull(right.hostPort, hostPort),
+                host: findNotNull(right.host, host)
+        )
+    }
+}

--- a/src/main/groovy/org/hidetake/groovy/ssh/extension/settings/RemotePortForwardSettings.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/extension/settings/RemotePortForwardSettings.groovy
@@ -1,0 +1,51 @@
+package org.hidetake.groovy.ssh.extension.settings
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import org.hidetake.groovy.ssh.core.settings.Settings
+
+import static org.hidetake.groovy.ssh.util.Utility.findNotNull
+
+/**
+ * Settings for the remote port forwarding.
+ *
+ * @author Hidetake Iwata
+ */
+@EqualsAndHashCode
+@ToString
+class RemotePortForwardSettings implements Settings<RemotePortForwardSettings> {
+    /**
+     * Local port to connect. (Mandatory)
+     */
+    Integer hostPort
+
+    /**
+     * Local host to connect. Defaults to localhost.
+     */
+    String host
+
+    /**
+     * Remote port to bind. (Mandatory)
+     */
+    Integer port
+
+    /**
+     * Remote host to bind. Default to localhost of the remote host.
+     */
+    String bind
+
+    static final DEFAULT = new RemotePortForwardSettings(
+            host: '127.0.0.1',
+            bind: '127.0.0.1',
+    )
+
+    @Override
+    RemotePortForwardSettings plus(RemotePortForwardSettings right) {
+        new RemotePortForwardSettings(
+                hostPort: findNotNull(right.hostPort, hostPort),
+                host: findNotNull(right.host, host),
+                port: findNotNull(right.port, port),
+                bind: findNotNull(right.bind, bind)
+        )
+    }
+}

--- a/src/main/groovy/org/hidetake/groovy/ssh/operation/DefaultOperations.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/operation/DefaultOperations.groovy
@@ -3,8 +3,10 @@ package org.hidetake.groovy.ssh.operation
 import groovy.util.logging.Slf4j
 import org.codehaus.groovy.tools.Utilities
 import org.hidetake.groovy.ssh.core.settings.LoggingMethod
+import org.hidetake.groovy.ssh.extension.settings.LocalPortForwardSettings
 import org.hidetake.groovy.ssh.core.settings.OperationSettings
 import org.hidetake.groovy.ssh.core.Remote
+import org.hidetake.groovy.ssh.extension.settings.RemotePortForwardSettings
 import org.hidetake.groovy.ssh.interaction.Stream
 import org.hidetake.groovy.ssh.session.BadExitStatusException
 import org.hidetake.groovy.ssh.connection.Connection
@@ -198,6 +200,21 @@ class DefaultOperations implements Operations {
             def result = lines.join(Utilities.eol())
             callback?.call(result)
         }
+    }
+
+    @Override
+    int forwardLocalPort(LocalPortForwardSettings settings) {
+        log.debug("Request port forwarding from local (${settings.bind}:${settings.port}) to remote (${settings.host}:${settings.hostPort})")
+        int port = connection.forwardLocalPort(settings)
+        log.debug("Enabled port forwarding from local (${settings.bind}:${port}) to remote (${settings.host}:${settings.hostPort})")
+        port
+    }
+
+    @Override
+    void forwardRemotePort(RemotePortForwardSettings settings) {
+        log.debug("Request port forwarding from remote (${settings.bind}:${settings.port}) to local (${settings.host}:${settings.hostPort})")
+        connection.forwardRemotePort(settings)
+        log.debug("Enabled port forwarding from remote (${settings.bind}:${settings.port}) to local (${settings.host}:${settings.hostPort})")
     }
 
     @Override

--- a/src/main/groovy/org/hidetake/groovy/ssh/operation/DryRunOperations.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/operation/DryRunOperations.groovy
@@ -1,7 +1,9 @@
 package org.hidetake.groovy.ssh.operation
 
+import org.hidetake.groovy.ssh.extension.settings.LocalPortForwardSettings
 import org.hidetake.groovy.ssh.core.settings.OperationSettings
 import org.hidetake.groovy.ssh.core.Remote
+import org.hidetake.groovy.ssh.extension.settings.RemotePortForwardSettings
 
 /**
  * Dry-run implementation of {@link Operations}.
@@ -29,6 +31,15 @@ class DryRunOperations implements Operations {
     @Override
     void executeBackground(OperationSettings settings, String command, Closure callback) {
         callback?.call('')
+    }
+
+    @Override
+    int forwardLocalPort(LocalPortForwardSettings settings) {
+        0
+    }
+
+    @Override
+    void forwardRemotePort(RemotePortForwardSettings settings) {
     }
 
     @Override

--- a/src/main/groovy/org/hidetake/groovy/ssh/operation/Operations.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/operation/Operations.groovy
@@ -1,7 +1,9 @@
 package org.hidetake.groovy.ssh.operation
 
+import org.hidetake.groovy.ssh.extension.settings.LocalPortForwardSettings
 import org.hidetake.groovy.ssh.core.settings.OperationSettings
 import org.hidetake.groovy.ssh.core.Remote
+import org.hidetake.groovy.ssh.extension.settings.RemotePortForwardSettings
 
 /**
  * An aggregate of core SSH operations.
@@ -16,6 +18,10 @@ interface Operations {
     String execute(OperationSettings settings, String command, Closure callback)
 
     void executeBackground(OperationSettings settings, String command, Closure callback)
+
+    int forwardLocalPort(LocalPortForwardSettings settings)
+
+    void forwardRemotePort(RemotePortForwardSettings settings)
 
     /**
      * Perform SFTP operations.

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/PortForwardingSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/PortForwardingSpec.groovy
@@ -1,0 +1,155 @@
+package org.hidetake.groovy.ssh.server
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import groovy.util.logging.Slf4j
+import groovyx.net.http.HttpResponseDecorator
+import groovyx.net.http.RESTClient
+import org.apache.sshd.SshServer
+import org.apache.sshd.common.ForwardingFilter
+import org.apache.sshd.common.SshdSocketAddress
+import org.apache.sshd.server.PasswordAuthenticator
+import org.hidetake.groovy.ssh.Ssh
+import org.hidetake.groovy.ssh.core.Service
+import spock.lang.Shared
+import spock.lang.Specification
+
+@org.junit.experimental.categories.Category(ServerIntegrationTest)
+@Slf4j
+class PortForwardingSpec extends Specification {
+
+    Service ssh
+
+    SshServer sshServer
+
+    @Shared HttpServer httpServer
+    @Shared int httpServerPort
+
+    def setupSpec() {
+        httpServerPort = SshServerMock.pickUpFreePort()
+        httpServer = HttpServer.create(new InetSocketAddress(httpServerPort), 0)
+        httpServer.createContext '/', { HttpExchange httpExchange ->
+            httpExchange.sendResponseHeaders(200, 0)
+            httpExchange.responseBody.close()
+        }
+        httpServer.start()
+    }
+
+    def setup() {
+        sshServer = SshServerMock.setUpLocalhostServer()
+        sshServer.passwordAuthenticator = Mock(PasswordAuthenticator)
+        sshServer.tcpipForwardingFilter = Mock(ForwardingFilter)
+        sshServer.start()
+
+        ssh = Ssh.newService()
+        ssh.settings {
+            knownHosts = allowAnyHosts
+        }
+        ssh.remotes {
+            some {
+                host = sshServer.host
+                port = sshServer.port
+                user = 'someUser'
+                password = 'somePassword'
+            }
+        }
+    }
+
+    def cleanup() {
+        sshServer.stop(true)
+    }
+
+    def cleanupSpec() {
+        httpServer.stop(0)
+    }
+
+    def "HTTP server should response 200"() {
+        when:
+        def response = new RESTClient("http://localhost:$httpServerPort").get(path: '/') as HttpResponseDecorator
+
+        then:
+        response.status == 200
+    }
+
+
+    def "auto allocated local port should be forwarded to the HTTP server"() {
+        when:
+        def response = ssh.run {
+            session(ssh.remotes.some) {
+                int port = forwardLocalPort(hostPort: httpServerPort)
+                new RESTClient("http://localhost:$port").get(path: '/')
+            }
+        }
+
+        then: (1.._) * sshServer.passwordAuthenticator.authenticate("someUser", "somePassword", _) >> true
+        then: 1 * sshServer.tcpipForwardingFilter.canConnect(_, _) >> true
+        then: response.status == 200
+    }
+
+    def "specified local port should be forwarded to the HTTP server"() {
+        when:
+        def response = ssh.run {
+            session(ssh.remotes.some) {
+                int port = SshServerMock.pickUpFreePort()
+                forwardLocalPort(port: port, hostPort: httpServerPort)
+                new RESTClient("http://localhost:$port").get(path: '/')
+            }
+        }
+
+        then: (1.._) * sshServer.passwordAuthenticator.authenticate("someUser", "somePassword", _) >> true
+        then: 1 * sshServer.tcpipForwardingFilter.canConnect(_, _) >> true
+        then: response.status == 200
+    }
+
+    def "specified local port should be forwarded to the HTTP server with addresses"() {
+        when:
+        def response = ssh.run {
+            session(ssh.remotes.some) {
+                int port = SshServerMock.pickUpFreePort()
+                forwardLocalPort(bind: '0.0.0.0', port: port, host: '0.0.0.0', hostPort: httpServerPort)
+                new RESTClient("http://localhost:$port").get(path: '/')
+            }
+        }
+
+        then: (1.._) * sshServer.passwordAuthenticator.authenticate("someUser", "somePassword", _) >> true
+        then: 1 * sshServer.tcpipForwardingFilter.canConnect(_, _) >> true
+        then: response.status == 200
+    }
+
+
+    def "specified remote port should be forwarded to the HTTP server"() {
+        when:
+        def response = ssh.run {
+            session(ssh.remotes.some) {
+                int port = SshServerMock.pickUpFreePort()
+                forwardRemotePort(port: port, hostPort: httpServerPort)
+                new RESTClient("http://localhost:$port").get(path: '/')
+            }
+        }
+
+        then: (1.._) * sshServer.passwordAuthenticator.authenticate("someUser", "somePassword", _) >> true
+        then: 1 * sshServer.tcpipForwardingFilter.canListen(_, _) >> true
+        then: response.status == 200
+    }
+
+    def "specified remote port should be forwarded to the HTTP server with addresses"() {
+        when:
+        def response = ssh.run {
+            session(ssh.remotes.some) {
+                int port = SshServerMock.pickUpFreePort()
+                forwardRemotePort(bind: '0.0.0.0', port: port, host: '0.0.0.0', hostPort: httpServerPort)
+                new RESTClient("http://localhost:$port").get(path: '/')
+            }
+        }
+
+        then: (1.._) * sshServer.passwordAuthenticator.authenticate("someUser", "somePassword", _) >> true
+        then: 1 * sshServer.tcpipForwardingFilter.canListen(_, _) >> true
+        then: response.status == 200
+    }
+
+
+    static addressOf(SshServer server) {
+        new SshdSocketAddress(server.host, server.port)
+    }
+
+}


### PR DESCRIPTION
This pull request adds port forwarding DSL such as `forwardLocalPort ` or `forwardRemotePort `. See #30 for details.

TODO:
* Review name of methods and settings
* Add more tests
* Documentation