### PR TITLE
Ignore failed exit status of command or shell

### DIFF
--- a/src/main/groovy/org/hidetake/groovy/ssh/core/settings/OperationSettings.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/core/settings/OperationSettings.groovy
@@ -38,6 +38,11 @@ class OperationSettings implements Settings<OperationSettings> {
     Boolean dryRun
 
     /**
+     * Ignores the exit status of the command or shell.
+     */
+    Boolean ignoreError
+
+    /**
      * PTY allocation flag.
      * If <code>true</code>, PTY will be allocated on command execution.
      */
@@ -76,6 +81,7 @@ class OperationSettings implements Settings<OperationSettings> {
 
     static final DEFAULT = new OperationSettings(
             dryRun: false,
+            ignoreError: false,
             pty: false,
             logging: Logging.slf4j,
             encoding: 'UTF-8',
@@ -85,6 +91,7 @@ class OperationSettings implements Settings<OperationSettings> {
     OperationSettings plus(OperationSettings right) {
         new OperationSettings(
                 dryRun:         findNotNull(right.dryRun, dryRun),
+                ignoreError: findNotNull(right.ignoreError, ignoreError),
                 pty:            findNotNull(right.pty, pty),
                 logging:        findNotNull(right.logging, logging),
                 encoding:       findNotNull(right.encoding, encoding),

--- a/src/main/groovy/org/hidetake/groovy/ssh/operation/DefaultOperations.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/operation/DefaultOperations.groovy
@@ -70,7 +70,8 @@ class DefaultOperations implements Operations {
 
             int exitStatus = channel.exitStatus
             log.info("Shell returned exit status $exitStatus on channel #${channel.id}")
-            if (exitStatus != 0) {
+
+            if (exitStatus != 0 && !settings.ignoreError) {
                 throw new BadExitStatusException("Shell returned exit status $exitStatus", exitStatus)
             }
         } finally {
@@ -128,7 +129,8 @@ class DefaultOperations implements Operations {
 
             int exitStatus = channel.exitStatus
             log.info("Command returned exit status $exitStatus on channel #${channel.id}")
-            if (exitStatus != 0) {
+
+            if (exitStatus != 0 && !settings.ignoreError) {
                 throw new BadExitStatusException("Command returned exit status $exitStatus", exitStatus)
             }
 
@@ -187,7 +189,8 @@ class DefaultOperations implements Operations {
         connection.whenClosed(channel) {
             int exitStatus = channel.exitStatus
             log.info("Command returned exit status $exitStatus on channel #${channel.id}")
-            if (exitStatus != 0) {
+
+            if (exitStatus != 0 && !settings.ignoreError) {
                 throw new BadExitStatusException("Command returned exit status $exitStatus", exitStatus)
             }
 

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/CommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/CommandExecutionSpec.groovy
@@ -101,6 +101,27 @@ class CommandExecutionSpec extends Specification {
         e.exitStatus == 1
     }
 
+    def "it should ignore the exit status if ignoreError is given"() {
+        given:
+        server.commandFactory = Mock(CommandFactory) {
+            1 * createCommand('somecommand') >> SshServerMock.command { SshServerMock.CommandContext c ->
+                c.outputStream.withWriter('UTF-8') { it << 'something output' }
+                c.exitCallback.onExit(1)
+            }
+        }
+        server.start()
+
+        when:
+        def resultActual = ssh.run {
+            session(ssh.remotes.testServer) {
+                execute 'somecommand', ignoreError: true
+            }
+        }
+
+        then:
+        resultActual == 'something output'
+    }
+
     @Unroll
     def "execute should return output of the command: #description"() {
         given:

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/ShellExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/ShellExecutionSpec.groovy
@@ -101,6 +101,24 @@ class ShellExecutionSpec extends Specification {
         e.exitStatus == 1
     }
 
+    def "it should ignore the exit status if ignoreError is given"() {
+        given:
+        server.shellFactory = Mock(Factory)
+        server.start()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                shell interaction: {}, ignoreError: true
+            }
+        }
+
+        then:
+        1 * server.shellFactory.create() >> SshServerMock.command { CommandContext c ->
+            c.exitCallback.onExit(1)
+        }
+    }
+
     @Unroll
     @ConfineMetaClassChanges(DefaultOperations)
     def "shell should write output to logger: #description"() {


### PR DESCRIPTION
To do:
* `ignoreExitStatus` is too long name. Need more intuitive one.
* At this time it ignores any exit status (actually 1 or higher). Need complex setting such as expected value or range?