### PR TITLE
Add feature to put a content into the remote file

### DIFF
--- a/src/main/groovy/org/hidetake/groovy/ssh/extension/SftpPut.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/extension/SftpPut.groovy
@@ -15,6 +15,32 @@ import static org.hidetake.groovy.ssh.operation.SftpException.Error.*
 @Slf4j
 class SftpPut {
     /**
+     * Put file(s) or content to the remote host.
+     *
+     * @param options file, files, into
+     */
+    void put(HashMap options) {
+        assert options.into, 'into must be given'
+
+        if (options.file) {
+            put(options.file, options.into)
+        } else if (options.files) {
+            put(options.files, options.into)
+        } else if (options.text) {
+            sftp(sftpPutContent.curry(options.text.toString().bytes, options.into))
+        } else if (options.bytes) {
+            assert options.bytes instanceof byte[], 'bytes must be an array of byte'
+            sftp(sftpPutContent.curry(options.bytes, options.into))
+        } else {
+            throw new IllegalArgumentException('options of put() must contains file, files, text or bytes')
+        }
+    }
+
+    private static final sftpPutContent = { byte[] content, String remoteFile ->
+        putContent(content, remoteFile)
+    }
+
+    /**
      * Put a file or directory to the remote host.
      *
      * @param local

--- a/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpOperations.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpOperations.groovy
@@ -49,6 +49,22 @@ class SftpOperations {
     }
 
     /**
+     * Put a content to the remote host.
+     *
+     * @param content
+     * @param remote path
+     */
+    void putContent(byte[] content, String remote) {
+        log.info("Put the content to remote ($remote)")
+        try {
+            def stream = new ByteArrayInputStream(content)
+            channel.put(stream, remote, new FileTransferLogger(), ChannelSftp.OVERWRITE)
+        } catch (JschSftpException e) {
+            throw new SftpException('Failed to put the content to the remote host', e)
+        }
+    }
+
+    /**
      * Create a directory.
      *
      * @param path

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/FileTransferSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/FileTransferSpec.groovy
@@ -109,6 +109,93 @@ class FileTransferSpec extends Specification {
         (destinationDir / sourceFile2.name).text == sourceFile2.text
     }
 
+    def "put() should accept a path string via map"() {
+        given:
+        def text = uuidgen()
+        def sourceFile = temporaryFolder.newFile() << text
+        def destinationFile = temporaryFolder.newFile()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                put file: sourceFile.path, into: destinationFile.path
+            }
+        }
+
+        then:
+        sourceFile.text == text
+        destinationFile.text == text
+    }
+
+    def "put() should accept a File object via map"() {
+        given:
+        def text = uuidgen()
+        def sourceFile = temporaryFolder.newFile() << text
+        def destinationFile = temporaryFolder.newFile()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                put file: sourceFile, into: destinationFile.path
+            }
+        }
+
+        then:
+        sourceFile.text == text
+        destinationFile.text == text
+    }
+
+    def "put() should accept a collection of file via map"() {
+        given:
+        def sourceDir = temporaryFolder.newFolder()
+        def sourceFile1 = sourceDir / uuidgen() << uuidgen()
+        def sourceFile2 = sourceDir / uuidgen() << uuidgen()
+        def destinationDir = temporaryFolder.newFolder()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                put files: [sourceFile1, sourceFile2], into: destinationDir.path
+            }
+        }
+
+        then:
+        (destinationDir / sourceFile1.name).text == sourceFile1.text
+        (destinationDir / sourceFile2.name).text == sourceFile2.text
+    }
+
+    def "put() should accept a string content via map"() {
+        given:
+        def text = uuidgen()
+        def destinationFile = temporaryFolder.newFile()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                put text: text, into: destinationFile.path
+            }
+        }
+
+        then:
+        destinationFile.text == text
+    }
+
+    def "put() should accept a byte array content via map"() {
+        given:
+        def text = uuidgen()
+        def destinationFile = temporaryFolder.newFile()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                put bytes: text.bytes, into: destinationFile.path
+            }
+        }
+
+        then:
+        destinationFile.text == text
+    }
+
     def "put() should overwrite a file if destination already exists"() {
         given:
         def text = uuidgen()
@@ -272,6 +359,76 @@ class FileTransferSpec extends Specification {
         then:
         AssertionError e = thrown()
         e.localizedMessage.contains 'remote'
+    }
+
+    def "put(file) should throw an error if into is not given"() {
+        given:
+        def file = temporaryFolder.newFile()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                put file: file.path
+            }
+        }
+
+        then:
+        AssertionError e = thrown()
+        e.localizedMessage.contains 'into'
+    }
+
+    def "put(files) should throw an error if into is not given"() {
+        given:
+        def file = temporaryFolder.newFile()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                put files: [file.path]
+            }
+        }
+
+        then:
+        AssertionError e = thrown()
+        e.localizedMessage.contains 'into'
+    }
+
+    def "put(text) should throw an error if into is not given"() {
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                put text: 'something'
+            }
+        }
+
+        then:
+        AssertionError e = thrown()
+        e.localizedMessage.contains 'into'
+    }
+
+    def "put(bytes) should throw an error if into is not given"() {
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                put bytes: 'something'
+            }
+        }
+
+        then:
+        AssertionError e = thrown()
+        e.localizedMessage.contains 'into'
+    }
+
+    def "put(options) should throw an error if options are invalid"() {
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                put invalid: 'option', into: 'file'
+            }
+        }
+
+        then:
+        thrown(IllegalArgumentException)
     }
 
 


### PR DESCRIPTION
It supports content of a string or byte array.

```groovy
put file: 'test.txt', into: '/tmp'
put file: new File('test.txt'), into: '/tmp'
put files: [new File('test.txt')], into: '/tmp'

put text: 'an example', into: '/tmp/test.txt'

byte[] data = ...
put bytes: data, into: '/tmp/test.db'
```

It accepts a multi-line string.

```groovy
put text: '''#!/bin/sh
exit 1
''', into: '/tmp/test.sh'
```
