### PR TITLE
Execute a script

### DIFF
--- a/src/main/groovy/org/hidetake/groovy/ssh/extension/CoreExtensions.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/extension/CoreExtensions.groovy
@@ -1,4 +1,4 @@
 package org.hidetake.groovy.ssh.extension
 
-trait CoreExtensions implements Command, BackgroundCommand, Shell, SudoExecution, SftpGet, SftpPut {
+trait CoreExtensions implements Command, BackgroundCommand, Shell, SudoExecution, SftpGet, SftpPut, ScriptExecution {
 }

--- a/src/main/groovy/org/hidetake/groovy/ssh/extension/ScriptExecution.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/extension/ScriptExecution.groovy
@@ -1,0 +1,76 @@
+package org.hidetake.groovy.ssh.extension
+
+import org.hidetake.groovy.ssh.session.SessionExtension
+
+/**
+ * An extension class to execute a script.
+ *
+ * @author hidetake.org
+ */
+trait ScriptExecution implements SessionExtension {
+
+    /**
+     * Execute the script.
+     *
+     * @param script script
+     * @return output value of the command
+     */
+    String executeScript(String script) {
+        withScript(script) { path ->
+            execute(path)
+        }
+    }
+
+    /**
+     * Execute the script.
+     *
+     * @param script script
+     * @param callback closure called with an output value of the command
+     */
+    void executeScript(String script, Closure callback) {
+        withScript(script) { path ->
+            execute(path, callback)
+        }
+    }
+
+    /**
+     * Execute the script.
+     *
+     * @param settings
+     * @param script script
+     * @return output value of the command
+     */
+    String executeScript(HashMap settings, String script) {
+        withScript(script) { path ->
+            execute(settings, path)
+        }
+    }
+
+    /**
+     * Execute the script.
+     *
+     * @param settings
+     * @param script script
+     * @param callback closure called with an output value of the command
+     */
+    void executeScript(HashMap settings, String script, Closure callback) {
+        withScript(script) { path ->
+            execute(settings, path, callback)
+        }
+    }
+
+    private def withScript(String script, Closure executor) {
+        def path = execute('mktemp || mktemp -t script', ignoreError: true, logging: 'none') ?: "/tmp/${UUID.randomUUID()}"
+        sftp {
+            putContent(new ByteArrayInputStream(), path)
+            try {
+                chmod(0700, path)
+                putContent(new ByteArrayInputStream(script.bytes), path)
+                executor.call(path)
+            } finally {
+                rm(path)
+            }
+        }
+    }
+
+}

--- a/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpOperations.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpOperations.groovy
@@ -79,6 +79,35 @@ class SftpOperations {
     }
 
     /**
+     * Change mode of the file or directory.
+     *
+     * @param permission
+     * @param path
+     */
+    void chmod(int permission, String path) {
+        log.info("Change permission of ($path) to ($permission)")
+        try {
+            channel.chmod(permission, path)
+        } catch (JschSftpException e) {
+            throw new SftpException('Failed to change permission', e)
+        }
+    }
+
+    /**
+     * Remove the file.
+     *
+     * @param path
+     */
+    void rm(String path) {
+        log.info("Remove file ($path)")
+        try {
+            channel.rm(path)
+        } catch (JschSftpException e) {
+            throw new SftpException('Failed to remove the file', e)
+        }
+    }
+
+    /**
      * Create a directory.
      *
      * @param path

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/ScriptExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/ScriptExecutionSpec.groovy
@@ -1,0 +1,178 @@
+package org.hidetake.groovy.ssh.server
+
+import org.apache.sshd.SshServer
+import org.apache.sshd.server.CommandFactory
+import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.sftp.SftpSubsystem
+import org.hidetake.groovy.ssh.Ssh
+import org.hidetake.groovy.ssh.core.Service
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static org.hidetake.groovy.ssh.server.SshServerMock.commandWithExit
+
+class ScriptExecutionSpec extends Specification {
+
+    SshServer server
+
+    Service ssh
+
+    @Rule
+    TemporaryFolder temporaryFolder
+
+    File temporaryFile
+
+    def setup() {
+        server = SshServerMock.setUpLocalhostServer()
+        server.subsystemFactories = [new SftpSubsystem.Factory()]
+        server.passwordAuthenticator = Mock(PasswordAuthenticator) {
+            (1.._) * authenticate('someuser', 'somepassword', _) >> true
+        }
+
+        ssh = Ssh.newService()
+        ssh.settings {
+            knownHosts = allowAnyHosts
+        }
+        ssh.remotes {
+            testServer {
+                host = server.host
+                port = server.port
+                user = 'someuser'
+                password = 'somepassword'
+            }
+        }
+
+        temporaryFile = temporaryFolder.newFile()
+    }
+
+    def cleanup() {
+        server.stop(true)
+    }
+
+
+    def "executeScript should put and execute a script"() {
+        given:
+        server.commandFactory = Mock(CommandFactory)
+        server.start()
+
+        when:
+        def result = ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript '''#!/bin/sh
+date
+'''
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(_) >> { String command ->
+            assert command.startsWith('mktemp')
+            commandWithExit(0, temporaryFile.path)
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(temporaryFile.path) >> {
+            assert temporaryFile.text == '''#!/bin/sh
+date
+'''
+            commandWithExit(0, 'something result')
+        }
+
+        then:
+        result == 'something result'
+        !temporaryFile.exists()
+    }
+
+    def "executeScript should work with settings"() {
+        given:
+        server.commandFactory = Mock(CommandFactory)
+        server.start()
+
+        when:
+        def result = ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript 'something', ignoreError: true
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(_) >> { String command ->
+            assert command.startsWith('mktemp')
+            commandWithExit(0, temporaryFile.path)
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(temporaryFile.path) >> {
+            assert temporaryFile.text == 'something'
+            commandWithExit(1, 'something result')
+        }
+
+        then:
+        result == 'something result'
+        !temporaryFile.exists()
+    }
+
+    def "executeScript should work with callback"() {
+        given:
+        server.commandFactory = Mock(CommandFactory)
+        server.start()
+
+        def result
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript('something') { result = it }
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(_) >> { String command ->
+            assert command.startsWith('mktemp')
+            commandWithExit(0, temporaryFile.path)
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(temporaryFile.path) >> {
+            assert temporaryFile.text == 'something'
+            commandWithExit(0, 'something result')
+        }
+
+        then:
+        result == 'something result'
+        !temporaryFile.exists()
+    }
+
+    def "executeScript should work with callback and settings"() {
+        given:
+        server.commandFactory = Mock(CommandFactory)
+        server.start()
+
+        def result
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript('something', ignoreError: true) { result = it }
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(_) >> { String command ->
+            assert command.startsWith('mktemp')
+            commandWithExit(0, temporaryFile.path)
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(temporaryFile.path) >> {
+            assert temporaryFile.text == 'something'
+            commandWithExit(1, 'something result')
+        }
+
+        then:
+        result == 'something result'
+        !temporaryFile.exists()
+    }
+
+}


### PR DESCRIPTION
This pull request provides the syntax to execute a script as like:
```groovy
session(remotes.server) {
  executeScript '''#!/bin/sh
echo 'hello world'
make world
'''
}
```