### PR TITLE
changes to test to run in Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.3.6'
+    compile 'org.codehaus.groovy:groovy-all:2.3.10'
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'com.jcraft:jsch:0.1.52'
     compile 'com.jcraft:jsch.agentproxy.connector-factory:0.0.7'
@@ -34,7 +34,7 @@ dependencies {
     cliRuntime 'ch.qos.logback:logback-classic:1.1.2'
     cliRuntime 'commons-cli:commons-cli:1.2'
 
-    testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
+    testCompile 'org.spockframework:spock-core:1.0-groovy-2.3'
     testCompile 'org.apache.sshd:sshd-core:0.14.0'
     testCompile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
 

--- a/src/test/groovy/org/hidetake/groovy/ssh/MainDryRunSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/MainDryRunSpec.groovy
@@ -48,7 +48,7 @@ class MainDryRunSpec extends Specification {
         then:
         JSchException e = thrown()
         e.cause instanceof ConnectException
-        e.cause.message == 'Connection refused'
+        e.cause.message.startsWith 'Connection refused'
     }
 
     @Unroll

--- a/src/test/groovy/org/hidetake/groovy/ssh/MainSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/MainSpec.groovy
@@ -6,6 +6,7 @@ import org.apache.sshd.server.PasswordAuthenticator
 import org.hidetake.groovy.ssh.fixture.HostKeyFixture
 import org.hidetake.groovy.ssh.operation.DefaultOperations
 import org.hidetake.groovy.ssh.server.SshServerMock
+import org.hidetake.groovy.ssh.util.FilenameUtils
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.slf4j.Logger
@@ -179,7 +180,7 @@ class MainSpec extends Specification {
         "ssh.run {" +
                 " session(host: 'localhost'," +
                 "  port: ${server.port}," +
-                "  knownHosts: new File('${knownHostsFile.path}')," +
+                "  knownHosts: new File('${FilenameUtils.toUnixSeparator(knownHostsFile.path)}')," +
                 "  user: 'someuser'," +
                 "  password: 'somepassword')" +
                 " { execute('somecommand') }" +

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/FileTransferSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/FileTransferSpec.groovy
@@ -6,6 +6,7 @@ import org.apache.sshd.server.sftp.SftpSubsystem
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import org.hidetake.groovy.ssh.operation.SftpException
+import org.hidetake.groovy.ssh.util.FilenameUtils
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Shared
@@ -23,7 +24,7 @@ class FileTransferSpec extends Specification {
     Service ssh
 
     @Rule
-    TemporaryFolder temporaryFolder
+    TemporaryFolder temporaryFolder=new TemporaryFolder(new File("build"))
 
     def setupSpec() {
         server = SshServerMock.setUpLocalhostServer()
@@ -64,7 +65,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put(sourceFile.path, destinationFile.path)
+                put(sourceFile.path, FilenameUtils.toUnixSeparator(destinationFile.path))
             }
         }
 
@@ -82,7 +83,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put(sourceFile, destinationFile.path)
+                put(sourceFile, FilenameUtils.toUnixSeparator(destinationFile.path))
             }
         }
 

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/FileTransferSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/FileTransferSpec.groovy
@@ -65,7 +65,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put(sourceFile.path, FilenameUtils.toUnixSeparator(destinationFile.path))
+                put(sourceFile.path, toUnixSeparator(destinationFile.path))
             }
         }
 
@@ -83,7 +83,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put(sourceFile, FilenameUtils.toUnixSeparator(destinationFile.path))
+                put(sourceFile, toUnixSeparator(destinationFile.path))
             }
         }
 
@@ -102,7 +102,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put([sourceFile1, sourceFile2], destinationDir.path)
+                put([sourceFile1, sourceFile2], toUnixSeparator(destinationDir.path))
             }
         }
 
@@ -120,7 +120,7 @@ class FileTransferSpec extends Specification {
         ssh.run {
             session(ssh.remotes.testServer) {
                 def stream = new ByteArrayInputStream(text.bytes)
-                put stream, destinationFile.path
+                put stream, toUnixSeparator(destinationFile.path)
             }
         }
 
@@ -137,7 +137,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put from: sourceFile.path, into: destinationFile.path
+                put from: sourceFile.path, into: toUnixSeparator(destinationFile.path)
             }
         }
 
@@ -155,7 +155,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put from: sourceFile, into: destinationFile.path
+                put from: sourceFile, into: toUnixSeparator(destinationFile.path)
             }
         }
 
@@ -174,7 +174,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put from: [sourceFile1, sourceFile2], into: destinationDir.path
+                put from: [sourceFile1, sourceFile2], into: toUnixSeparator(destinationDir.path)
             }
         }
 
@@ -191,7 +191,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put text: text, into: destinationFile.path
+                put text: text, into: toUnixSeparator(destinationFile.path)
             }
         }
 
@@ -207,7 +207,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put bytes: text.bytes, into: destinationFile.path
+                put bytes: text.bytes, into: toUnixSeparator(destinationFile.path)
             }
         }
 
@@ -224,7 +224,7 @@ class FileTransferSpec extends Specification {
         ssh.run {
             session(ssh.remotes.testServer) {
                 def stream = new ByteArrayInputStream(text.bytes)
-                put from: stream, into: destinationFile.path
+                put from: stream, into: toUnixSeparator(destinationFile.path)
             }
         }
 
@@ -241,7 +241,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put(sourceFile.path, destinationFile.path)
+                put(sourceFile.path, toUnixSeparator(destinationFile.path))
             }
         }
 
@@ -259,7 +259,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put(sourceFile, destinationDir.path)
+                put(sourceFile, toUnixSeparator(destinationDir.path))
             }
         }
 
@@ -280,7 +280,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put(sourceFile, destinationDir.path)
+                put(sourceFile, toUnixSeparator(destinationDir.path))
             }
         }
 
@@ -304,7 +304,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put(source1Dir, destinationDir.path)
+                put(source1Dir, toUnixSeparator(destinationDir.path))
             }
         }
 
@@ -334,7 +334,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put(source1Dir, destination0Dir.path)
+                put(source1Dir, toUnixSeparator(destination0Dir.path))
             }
         }
 
@@ -357,7 +357,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                put(sourceDir, destinationDir.path)
+                put(sourceDir, toUnixSeparator(destinationDir.path))
             }
         }
 
@@ -440,7 +440,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get(sourceFile.path, destinationFile.path)
+                get(toUnixSeparator(sourceFile.path), destinationFile.path)
             }
         }
 
@@ -458,7 +458,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get(sourceFile.path, destinationFile)
+                get(toUnixSeparator(sourceFile.path), destinationFile)
             }
         }
 
@@ -476,7 +476,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get sourceFile.path, outputStream
+                get toUnixSeparator(sourceFile.path), outputStream
             }
         }
 
@@ -494,7 +494,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get from: sourceFile.path, into: destinationFile.path
+                get from: toUnixSeparator(sourceFile.path), into: destinationFile.path
             }
         }
 
@@ -512,7 +512,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get from: sourceFile.path, into: destinationFile
+                get from: toUnixSeparator(sourceFile.path), into: destinationFile
             }
         }
 
@@ -530,7 +530,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get from: sourceFile.path, into: outputStream
+                get from: toUnixSeparator(sourceFile.path), into: outputStream
             }
         }
 
@@ -547,7 +547,7 @@ class FileTransferSpec extends Specification {
         when:
         def content = ssh.run {
             session(ssh.remotes.testServer) {
-                get from: sourceFile.path
+                get from: toUnixSeparator(sourceFile.path)
             }
         }
 
@@ -565,7 +565,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get(sourceFile.path, destinationFile.path)
+                get(toUnixSeparator(sourceFile.path), destinationFile.path)
             }
         }
 
@@ -583,7 +583,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get(sourceFile.path, destinationDir)
+                get(toUnixSeparator(sourceFile.path), destinationDir)
             }
         }
 
@@ -605,7 +605,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get(sourceFile.path, destinationDir)
+                get(toUnixSeparator(sourceFile.path), destinationDir)
             }
         }
 
@@ -629,7 +629,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get(source1Dir.path, destinationDir)
+                get(toUnixSeparator(source1Dir.path), destinationDir)
             }
         }
 
@@ -659,7 +659,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get(source1Dir.path, destination0Dir)
+                get(toUnixSeparator(source1Dir.path), destination0Dir)
             }
         }
 
@@ -682,7 +682,7 @@ class FileTransferSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                get(sourceDir.path, destinationDir)
+                get(toUnixSeparator(sourceDir.path), destinationDir)
             }
         }
 
@@ -768,6 +768,10 @@ class FileTransferSpec extends Specification {
 
     static uuidgen() {
         UUID.randomUUID().toString()
+    }
+
+    static String toUnixSeparator(String path){
+        FilenameUtils.toUnixSeparator(path)
     }
 
 }

--- a/src/test/groovy/org/hidetake/groovy/ssh/server/PortForwardingSpec.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/server/PortForwardingSpec.groovy
@@ -106,7 +106,7 @@ class PortForwardingSpec extends Specification {
         def response = ssh.run {
             session(ssh.remotes.some) {
                 int port = SshServerMock.pickUpFreePort()
-                forwardLocalPort(bind: '0.0.0.0', port: port, host: '0.0.0.0', hostPort: httpServerPort)
+                forwardLocalPort(bind: '0.0.0.0', port: port, host: 'localhost', hostPort: httpServerPort)
                 new RESTClient("http://localhost:$port").get(path: '/')
             }
         }

--- a/src/test/groovy/org/hidetake/groovy/ssh/util/FilenameUtils.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/util/FilenameUtils.groovy
@@ -3,6 +3,10 @@ package org.hidetake.groovy.ssh.util
 class FilenameUtils {
 
     static String toUnixSeparator(String path){
-        path.replaceAll('\\\\','/')
+        isWindows()?path.replaceAll('\\\\','/'):path
+    }
+
+    static boolean isWindows(){
+        System.properties['os.name'].toLowerCase().contains('windows')
     }
 }

--- a/src/test/groovy/org/hidetake/groovy/ssh/util/FilenameUtils.groovy
+++ b/src/test/groovy/org/hidetake/groovy/ssh/util/FilenameUtils.groovy
@@ -1,0 +1,8 @@
+package org.hidetake.groovy.ssh.util
+
+class FilenameUtils {
+
+    static String toUnixSeparator(String path){
+        path.replaceAll('\\\\','/')
+    }
+}


### PR DESCRIPTION
Hi,
I had some problem in running tests in Windows. These are the changes I performed, and now tests are 100% OK. Changes are only in the test code, not in the main code.
I upgraded spock version to 1.0: it uses Junit 4.12 which allows to set a base directory when creating temporary files and folders. This because I have my project on a different disk unit than the one with the default temporary folder (based on C: unit), and in this case the sftp test failed. Besides, I think it is better to keep generated files inside the project directory.
Then I added an utility method to replace backslash with forward slash for the files and folders meant to be on a un*x server.
Another couple of issues I had:
* the connection failed message was "'Connection refused: connect', so I just amended the text to match just the start of the message
* In the "forward port" tests I had an error trying to open a remote port on every interface (0.0.0.0), so I switched to the "localhost" interface; I guess the test should not lose generality.