### PR TITLE
Add SSH keep-alive setting

### DIFF
--- a/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
@@ -87,13 +87,16 @@ class ConnectionManager {
         assert settings.knownHosts   != null, 'knownHosts must not be null'
         assert settings.retryCount   != null, 'retryCount must not be null'
         assert settings.retryWaitSec != null, 'retryWaitSec must not be null'
+        assert settings.keepAliveSec != null, 'keepAliveMillis must not be null'
         assert settings.retryCount   >= 0, "retryCount must be zero or positive (remote ${remote.name})"
         assert settings.retryWaitSec >= 0, "retryWaitSec must be zero or positive (remote ${remote.name})"
+        assert settings.keepAliveSec >= 0, "keepAliveMillis must be zero or positive (remote ${remote.name})"
 
         JSch.logger = JSchLogger.instance
         def jsch = new JSch()
         def session = jsch.getSession(settings.user, host, port)
         session.setConfig('PreferredAuthentications', 'publickey,keyboard-interactive,password')
+        session.setServerAliveInterval(settings.keepAliveSec * 1000)
 
         if (settings.knownHosts == ConnectionSettings.Constants.allowAnyHosts) {
             session.setConfig('StrictHostKeyChecking', 'no')

--- a/src/main/groovy/org/hidetake/groovy/ssh/core/settings/ConnectionSettings.groovy
+++ b/src/main/groovy/org/hidetake/groovy/ssh/core/settings/ConnectionSettings.groovy
@@ -64,6 +64,11 @@ class ConnectionSettings implements Settings<ConnectionSettings> {
      */
     Integer retryWaitSec
 
+    /**
+     * Interval time in seconds between keep-alive packets.
+     */
+    Integer keepAliveSec
+
 
     /**
      * Represents that strict host key checking is turned off and any host is allowed.
@@ -85,7 +90,8 @@ class ConnectionSettings implements Settings<ConnectionSettings> {
             agent: false,
             knownHosts: new File("${System.properties['user.home']}/.ssh/known_hosts"),
             retryCount: 0,
-            retryWaitSec: 0
+            retryWaitSec: 0,
+            keepAliveSec: 60,
     )
 
     ConnectionSettings plus(ConnectionSettings right) {
@@ -99,6 +105,7 @@ class ConnectionSettings implements Settings<ConnectionSettings> {
                 knownHosts:   findNotNull(right.knownHosts, knownHosts),
                 retryCount:   findNotNull(right.retryCount, retryCount),
                 retryWaitSec: findNotNull(right.retryWaitSec, retryWaitSec),
+                keepAliveSec: findNotNull(right.keepAliveSec, keepAliveSec),
         )
     }
 


### PR DESCRIPTION
This pull request adds a setting of SSH keep-alive and enables it at default.

```groovy
ssh.remotes {
  example {
    keepAliveSec = 60
  }
}
```