### PR TITLE
Improve identity can be provided as a string

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/ConnectionSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/ConnectionSettings.groovy
@@ -12,7 +12,7 @@ import static org.hidetake.groovy.ssh.util.Utility.findNotNull
  * @author Hidetake Iwata
  */
 @EqualsAndHashCode
-@ToString(excludes = 'password, passphrase, allowAnyHosts')
+@ToString(excludes = 'password, identity, passphrase, allowAnyHosts')
 class ConnectionSettings implements Settings<ConnectionSettings> {
     /**
      * Remote user.
@@ -21,14 +21,16 @@ class ConnectionSettings implements Settings<ConnectionSettings> {
 
     /**
      * Password.
-     * Leave as null if public key authentication.
+     * Leave as null if the password authentication is not needed.
      */
     String password
 
     /**
      * Identity key file for public-key authentication.
+     * This must be a {@link File}, {@link String} or null.
+     * Leave as null if the public key authentication is not needed.
      */
-    File identity
+    def identity
 
     /**
      * Pass-phrase for the identity key.

--- a/core/src/test/groovy/org/hidetake/groovy/ssh/core/settings/ConnectionSettingsSpec.groovy
+++ b/core/src/test/groovy/org/hidetake/groovy/ssh/core/settings/ConnectionSettingsSpec.groovy
@@ -95,7 +95,7 @@ class ConnectionSettingsSpec extends Specification {
         then:
         result.contains('theUser')
         !result.contains('thePassword')
-        result.contains('theIdentity')
+        !result.contains('theIdentity')
         !result.contains('thePassphrase')
     }
 

--- a/docs/src/docs/asciidoc/user-guide.adoc
+++ b/docs/src/docs/asciidoc/user-guide.adoc
@@ -42,7 +42,7 @@ Also following settings can be set in a remote closure. These can be set globall
 |Key            | Type              | Description
 |`user`         | String, Mandatory | User name.
 |`password`     | String            | A password for password authentication. Defaults to null (no password authentication).
-|`identity`     | File              | A private key for public-key authentication. Defaults to null (no public-key authentication).
+|`identity`     | File or String    | A private key for public-key authentication. This can be a key File or key content String. Defaults to null (no public-key authentication).
 |`passphrase`   | String            | A pass-phrase of the private key. Defaults to null (no pass-phrase).
 |`agent`        | Boolean           | A flag to use Putty Agent or ssh-agent on authentication. Defaults to false.
 |`knownHosts`   | File              | A known hosts file. Defaults to `~/.ssh/known_hosts`. If `allowAnyHosts` is set, strict host key checking is turned off (only for testing purpose).


### PR DESCRIPTION
This pull request provides the feature: identity can be set as a File or String.
https://github.com/int128/gradle-ssh-plugin/issues/183