### PR TITLE
Allow passphrase to be defined as a Closure

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/ConnectionSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/ConnectionSettings.groovy
@@ -34,9 +34,9 @@ class ConnectionSettings implements Settings<ConnectionSettings> {
 
     /**
      * Pass-phrase for the identity key.
-     * This may be null.
+     * This may be null. It may also be a Closure.
      */
-    String passphrase
+    def passphrase
 
     /**
      * Proxy configuration for connecting to a host.
@@ -71,7 +71,7 @@ class ConnectionSettings implements Settings<ConnectionSettings> {
      */
     Integer keepAliveSec
 
-
+    
     /**
      * Represents that strict host key checking is turned off and any host is allowed.
      * @see ConnectionSettings#knownHosts
@@ -96,6 +96,13 @@ class ConnectionSettings implements Settings<ConnectionSettings> {
             keepAliveSec: 60,
     )
 
+    public String getPassphrase(){
+        if(passphrase instanceof Closure){
+            return passphrase()
+        }
+        passphrase
+    }
+    
     ConnectionSettings plus(ConnectionSettings right) {
         new ConnectionSettings(
                 user:         findNotNull(right.user, user),

--- a/core/src/test/groovy/org/hidetake/groovy/ssh/core/settings/ConnectionSettingsSpec.groovy
+++ b/core/src/test/groovy/org/hidetake/groovy/ssh/core/settings/ConnectionSettingsSpec.groovy
@@ -99,4 +99,16 @@ class ConnectionSettingsSpec extends Specification {
         !result.contains('thePassphrase')
     }
 
+    def "passphrase should be able to be defined as a Closure"() {
+        given:
+        def settings = new ConnectionSettings(
+            user: 'theUser', password:'thePassword',
+            identity: new File('theIdentity'), passphrase: { "x" * 2 }
+        )
+        when:
+        def passphrase = settings.passphrase
+        
+        then:
+        passphrase == "xx"
+    }
 }


### PR DESCRIPTION
This allows to prompt the user for a passphrase with an application-dependent method in order to avoid keeping passwords in config-files.
E.g. `passphrase = {return System.in.newReader().readLine()}`
It is still possible to assign a String. Using a Closure is optional.

I propose this change, because:

- I'm currently using org.hidetake:gradle-ssh-plugin as part of a gradle based project
- I need to distribute the build with a password-protected key
- I don't want to store the password in a config file and I don't want to force other developers of that project to setup an ssh-agent.

This change would allow to ask for the passphrase when it's needed during build. 

E.g.
```
server {
                host = ssh_host
                user = ssh_user
                identity = file(ssh_identity)
                passphrase={
                	println ""
                	println "X"*20
                	println "XXX Please enter password for ${user}@${host} using ${ssh_identity}" 
                	println "X"*20
                	println ""
                	return System.in.newReader().readLine() 
                }
}
```
I would very much appreciate the acceptance of this pull request. 
