### PR TITLE
Fix bug sftp method always returns null

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/DefaultOperations.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/DefaultOperations.groovy
@@ -197,14 +197,15 @@ class DefaultOperations implements Operations {
     }
 
     @Override
-    def sftp(Closure closure) {
+    def <T> T sftp(Closure<T> closure) {
         log.debug("Requesting SFTP subsystem on $remote")
         def channel = connection.createSftpChannel()
         channel.connect()
         try {
             log.debug("Started SFTP $remote.name#$channel.id")
-            callWithDelegate(closure, new SftpOperations(remote, channel))
-            log.debug("Completed SFTP $remote.name#$channel.id")
+            def result = callWithDelegate(closure, new SftpOperations(remote, channel))
+            log.debug("Finished SFTP $remote.name#$channel.id")
+            result
         } finally {
             channel.disconnect()
         }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/DryRunOperations.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/DryRunOperations.groovy
@@ -54,7 +54,8 @@ class DryRunOperations implements Operations {
     }
 
     @Override
-    def sftp(Closure closure) {
+    def <T> T sftp(Closure<T> closure) {
         log.info("Requesting SFTP subsystem on $remote")
+        null
     }
 }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/Operations.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/Operations.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.operation
 
-import org.hidetake.groovy.ssh.extension.settings.LocalPortForwardSettings
-import org.hidetake.groovy.ssh.core.settings.OperationSettings
 import org.hidetake.groovy.ssh.core.Remote
+import org.hidetake.groovy.ssh.core.settings.OperationSettings
+import org.hidetake.groovy.ssh.extension.settings.LocalPortForwardSettings
 import org.hidetake.groovy.ssh.extension.settings.RemotePortForwardSettings
 
 /**
@@ -29,5 +29,5 @@ interface Operations {
      * @param closure closure for {@link SftpOperations}
      * @return result of the closure
      */
-    def sftp(@DelegatesTo(SftpOperations) Closure closure)
+    def <T> T sftp(@DelegatesTo(SftpOperations) Closure<T> closure)
 }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionExtension.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionExtension.groovy
@@ -25,7 +25,7 @@ trait SessionExtension {
      * @param closure closure for {@link org.hidetake.groovy.ssh.operation.SftpOperations}
      * @return result of the closure
      */
-    abstract def sftp(@DelegatesTo(SftpOperations) Closure closure)
+    abstract def <T> T sftp(@DelegatesTo(SftpOperations) Closure<T> closure)
 
     /**
      * Return the current {@link Operations}.

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionHandler.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionHandler.groovy
@@ -58,7 +58,7 @@ class SessionHandler implements CoreExtensions {
     }
 
     @Override
-    def sftp(@DelegatesTo(SftpOperations) Closure closure) {
+    def <T> T sftp(@DelegatesTo(SftpOperations) Closure<T> closure) {
         assert closure, 'closure must be given'
         operations.sftp(closure)
     }


### PR DESCRIPTION
This fixes `sftp {}` method to return value of the inner closure.