### PR TITLE
Add agentForwarding property when execute a command

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/Connection.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/Connection.groovy
@@ -40,6 +40,7 @@ class Connection {
         def channel = session.openChannel('exec') as ChannelExec
         channel.command = command
         channel.pty = operationSettings.pty
+		channel.agent_forwarding = operationSettings.agentForwarding
         channels.add(channel)
         channel
     }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/OperationSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/OperationSettings.groovy
@@ -30,6 +30,12 @@ class OperationSettings implements Settings<OperationSettings> {
      */
     Boolean pty
 
+	/**
+	 * Use agentForwarding flag.
+	 * If <code>true</code>, agent will be forwarded to remote host.
+	 */
+	Boolean agentForwarding
+	
     /**
      * A logging method of the remote command or shell.
      */
@@ -65,6 +71,7 @@ class OperationSettings implements Settings<OperationSettings> {
             dryRun: false,
             ignoreError: false,
             pty: false,
+            agentForwarding: false,
             logging: LoggingMethod.slf4j,
             encoding: 'UTF-8',
             extensions: []
@@ -75,6 +82,7 @@ class OperationSettings implements Settings<OperationSettings> {
                 dryRun:         findNotNull(right.dryRun, dryRun),
                 ignoreError: findNotNull(right.ignoreError, ignoreError),
                 pty:            findNotNull(right.pty, pty),
+                agentForwarding: findNotNull(right.agentForwarding, agentForwarding),
                 logging:        findNotNull(right.logging, logging),
                 encoding:       findNotNull(right.encoding, encoding),
                 interaction:    findNotNull(right.interaction, interaction),

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/CommandSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/CommandSpec.groovy
@@ -48,6 +48,7 @@ class CommandSpec extends Specification {
                 user = 'someuser'
                 password = 'somepassword'
             }
+			
         }
     }
 
@@ -153,7 +154,7 @@ class CommandSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.testServer) {
-                execute('somecommand', pty: true) { result ->
+                execute('somecommand', pty: true, agentForwarding: true) { result ->
                     resultActual = result
                 }
             }


### PR DESCRIPTION
I don't know how to test agent forwarding using a mock ssh server, so
I have tested it manually and it works fine.
I have yust modified:
  "CommandSpec.execute can return value via callback with setting"
to use both pty and agentForwarding.
The flag is setted only per command execution but it will be usefull
also per scp.
Moreover a per host setting will be more simple to use