### PR TITLE
Improve Settings.toString for log readability

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
@@ -86,6 +86,7 @@ class ConnectionManager {
      */
     private Session establishSession(Remote remote, String host, int port) {
         def settings = connectionSettings + remote.connectionSettings
+        log.debug("Connecting to $remote with $settings")
 
         assert settings.user, "user must be given (remote ${remote.name})"
         assert settings.knownHosts   != null, 'knownHosts must not be null'

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionSettings.groovy
@@ -1,10 +1,10 @@
 package org.hidetake.groovy.ssh.connection
 
 import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
 import org.hidetake.groovy.ssh.core.Proxy
 import org.hidetake.groovy.ssh.core.Remote
 import org.hidetake.groovy.ssh.core.settings.Settings
+import org.hidetake.groovy.ssh.core.settings.ToStringProperties
 
 import static org.hidetake.groovy.ssh.util.Utility.findNotNull
 
@@ -14,8 +14,7 @@ import static org.hidetake.groovy.ssh.util.Utility.findNotNull
  * @author Hidetake Iwata
  */
 @EqualsAndHashCode
-@ToString(excludes = 'password, identity, passphrase, allowAnyHosts')
-class ConnectionSettings implements Settings<ConnectionSettings> {
+class ConnectionSettings implements Settings<ConnectionSettings>, ToStringProperties {
     /**
      * Remote user.
      */
@@ -28,6 +27,11 @@ class ConnectionSettings implements Settings<ConnectionSettings> {
     String password
 
     /**
+     * {@link #toString()} formatter to hide credential.
+     */
+    final toString__password() { '...' }
+
+    /**
      * Identity key file for public-key authentication.
      * This must be a {@link File}, {@link String} or null.
      * Leave as null if the public key authentication is not needed.
@@ -35,10 +39,20 @@ class ConnectionSettings implements Settings<ConnectionSettings> {
     def identity
 
     /**
+     * {@link #toString()} formatter to hide credential.
+     */
+    final toString__identity() { identity instanceof File ? identity : '...' }
+
+    /**
      * Pass-phrase for the identity key.
      * This may be null.
      */
     String passphrase
+
+    /**
+     * {@link #toString()} formatter to hide credential.
+     */
+    final toString__passphrase() { '...' }
 
     /**
      * Gateway host.
@@ -85,6 +99,11 @@ class ConnectionSettings implements Settings<ConnectionSettings> {
      * @see ConnectionSettings#knownHosts
      */
     final File allowAnyHosts = Constants.allowAnyHosts
+
+    /**
+     * {@link #toString()} formatter to hide the constant.
+     */
+    final toString__allowAnyHosts() {}
 
     static class Constants {
         static final allowAnyHosts = new File("${ConnectionSettings.class.name}#allowAnyHosts")

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/Remote.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/Remote.groovy
@@ -49,7 +49,10 @@ class Remote {
      */
     final List<String> roles = []
 
-    @Delegate
+    /**
+     * Delegates connection settings excluding traits to avoid side-effect.
+     */
+    @Delegate(interfaces = false)
     ConnectionSettings connectionSettings = new ConnectionSettings()
 
     void role(String role) {

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/Service.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/Service.groovy
@@ -1,5 +1,6 @@
 package org.hidetake.groovy.ssh.core
 
+import groovy.util.logging.Slf4j
 import org.hidetake.groovy.ssh.core.container.ContainerBuilder
 import org.hidetake.groovy.ssh.core.container.ProxyContainer
 import org.hidetake.groovy.ssh.core.container.RemoteContainer
@@ -13,6 +14,7 @@ import static org.hidetake.groovy.ssh.util.Utility.callWithDelegate
  *
  * @author Hidetake Iwata
  */
+@Slf4j
 class Service {
     /**
      * Container of remote hosts.
@@ -72,6 +74,9 @@ class Service {
         def handler = new RunHandler()
         callWithDelegate(closure, handler)
 
+        log.debug("Using default settings: $CompositeSettings.DEFAULT")
+        log.debug("Using global settings: $settings")
+        log.debug("Using per-service settings: $handler.settings")
         def executor = new Executor(CompositeSettings.DEFAULT + settings + handler.settings)
 
         def results = executor.execute(handler.sessions)

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/CompositeSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/CompositeSettings.groovy
@@ -1,7 +1,6 @@
 package org.hidetake.groovy.ssh.core.settings
 
 import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
 import org.hidetake.groovy.ssh.connection.ConnectionSettings
 import org.hidetake.groovy.ssh.operation.CommandSettings
 import org.hidetake.groovy.ssh.session.SessionSettings
@@ -14,8 +13,7 @@ import org.hidetake.groovy.ssh.session.SessionSettings
  * @author Hidetake Iwata
  */
 @EqualsAndHashCode
-@ToString
-class CompositeSettings implements Settings<CompositeSettings> {
+class CompositeSettings implements Settings<CompositeSettings>, ToStringProperties {
     @Delegate
     ConnectionSettings connectionSettings = new ConnectionSettings()
 

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/ToStringProperties.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/ToStringProperties.groovy
@@ -1,0 +1,40 @@
+package org.hidetake.groovy.ssh.core.settings
+
+/**
+ * A trait for overriding {@link Object#toString()} to show properties of this object.
+ * This may help debug by user friendly log.
+ *
+ * @author Hidetake Iwata
+ */
+trait ToStringProperties {
+    /**
+     * Returns a string representation of this settings.
+     * Class should implements method <code>toString__<i>propertyName</i></code>
+     * to exclude or customize property representation.
+     * See test for details of specification.
+     *
+     * @returns string representation of this settings
+     */
+    @Override
+    String toString() {
+        '{' + properties.findAll { key, value ->
+            // prevents recursion
+            !(value instanceof ToStringProperties) &&
+            // excludes class
+            key != 'class' &&
+            // excludes if value is null
+            value != null
+        }.collectEntries { key, value ->
+            try {
+                [(key): "toString__$key"()]
+            } catch (MissingMethodException ignore) {
+                [(key): value]
+            }
+        }.findAll { key, value ->
+            // excludes if the formatter returns null
+            value != null
+        }.collect { key, value ->
+            "$key=${value.toString()}"
+        }.join(', ') + '}'
+    }
+}

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/extension/settings/LocalPortForwardSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/extension/settings/LocalPortForwardSettings.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.extension.settings
 
 import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
 import org.hidetake.groovy.ssh.core.settings.Settings
+import org.hidetake.groovy.ssh.core.settings.ToStringProperties
 
 import static org.hidetake.groovy.ssh.util.Utility.findNotNull
 
@@ -12,8 +12,7 @@ import static org.hidetake.groovy.ssh.util.Utility.findNotNull
  * @author Hidetake Iwata
  */
 @EqualsAndHashCode
-@ToString
-class LocalPortForwardSettings implements Settings<LocalPortForwardSettings> {
+class LocalPortForwardSettings implements Settings<LocalPortForwardSettings>, ToStringProperties {
     /**
      * Local port to bind. Defaults to 0 (allocate free port).
      */

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/extension/settings/RemotePortForwardSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/extension/settings/RemotePortForwardSettings.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.extension.settings
 
 import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
 import org.hidetake.groovy.ssh.core.settings.Settings
+import org.hidetake.groovy.ssh.core.settings.ToStringProperties
 
 import static org.hidetake.groovy.ssh.util.Utility.findNotNull
 
@@ -12,8 +12,7 @@ import static org.hidetake.groovy.ssh.util.Utility.findNotNull
  * @author Hidetake Iwata
  */
 @EqualsAndHashCode
-@ToString
-class RemotePortForwardSettings implements Settings<RemotePortForwardSettings> {
+class RemotePortForwardSettings implements Settings<RemotePortForwardSettings>, ToStringProperties {
     /**
      * Local port to connect. (Mandatory)
      */

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/CommandSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/CommandSettings.groovy
@@ -1,9 +1,9 @@
 package org.hidetake.groovy.ssh.operation
 
 import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
 import org.hidetake.groovy.ssh.core.settings.LoggingMethod
 import org.hidetake.groovy.ssh.core.settings.Settings
+import org.hidetake.groovy.ssh.core.settings.ToStringProperties
 
 import static org.hidetake.groovy.ssh.util.Utility.findNotNull
 
@@ -13,8 +13,7 @@ import static org.hidetake.groovy.ssh.util.Utility.findNotNull
  * @author Hidetake Iwata
  */
 @EqualsAndHashCode
-@ToString
-class CommandSettings implements Settings<CommandSettings> {
+class CommandSettings implements Settings<CommandSettings>, ToStringProperties {
     /**
      * Ignores the exit status of the command or shell.
      */

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/Executor.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/Executor.groovy
@@ -38,7 +38,7 @@ class Executor {
     }
 
     private <T> List<T> dryRun(List<Plan<T>> plans) {
-        log.debug("Running ${plans.size()} session(s) as dry-run")
+        log.debug("Running ${plans.size()} session(s) with $settings")
         plans.collect { plan ->
             def operations = new DryRunOperations(plan.remote)
             callWithDelegate(plan.closure, SessionHandler.create(operations, settings))
@@ -46,7 +46,7 @@ class Executor {
     }
 
     private <T> List<T> wetRun(List<Plan<T>> plans) {
-        log.debug("Running ${plans.size()} session(s)")
+        log.debug("Running ${plans.size()} session(s) with $settings")
         def manager = new ConnectionManager(settings.connectionSettings)
         try {
             plans.collect { plan ->

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionSettings.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.session
 
 import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
 import org.hidetake.groovy.ssh.core.settings.Settings
+import org.hidetake.groovy.ssh.core.settings.ToStringProperties
 
 import static org.hidetake.groovy.ssh.util.Utility.findNotNull
 
@@ -12,8 +12,7 @@ import static org.hidetake.groovy.ssh.util.Utility.findNotNull
  * @author Hidetake Iwata
  */
 @EqualsAndHashCode
-@ToString
-class SessionSettings implements Settings<SessionSettings> {
+class SessionSettings implements Settings<SessionSettings>, ToStringProperties {
     /**
      * Dry-run flag.
      * If <code>true</code>, performs no action.
@@ -24,6 +23,11 @@ class SessionSettings implements Settings<SessionSettings> {
      * Extensions for {@link org.hidetake.groovy.ssh.session.SessionHandler}.
      */
     List extensions = []
+
+    /**
+     * Do not show if it is empty or null.
+     */
+    final toString__extensions() { extensions ? extensions : null }
 
     static final DEFAULT = new SessionSettings(
             dryRun: false,

--- a/core/src/test/groovy/org/hidetake/groovy/ssh/connection/ConnectionSettingsSpec.groovy
+++ b/core/src/test/groovy/org/hidetake/groovy/ssh/connection/ConnectionSettingsSpec.groovy
@@ -86,7 +86,7 @@ class ConnectionSettingsSpec extends Specification {
         given:
         def settings = new ConnectionSettings(
                 user: 'theUser', password: 'thePassword',
-                identity: new File('theIdentity'), passphrase: 'thePassphrase'
+                identity: 'theIdentity', passphrase: 'thePassphrase'
         )
 
         when:
@@ -96,6 +96,23 @@ class ConnectionSettingsSpec extends Specification {
         result.contains('theUser')
         !result.contains('thePassword')
         !result.contains('theIdentity')
+        !result.contains('thePassphrase')
+    }
+
+    def "result of ToString() contains identity if it is a File"() {
+        given:
+        def settings = new ConnectionSettings(
+                user: 'theUser', password: 'thePassword',
+                identity: new File('theIdentity'), passphrase: 'thePassphrase'
+        )
+
+        when:
+        def result = settings.toString()
+
+        then:
+        result.contains('theUser')
+        !result.contains('thePassword')
+        result.contains('theIdentity')
         !result.contains('thePassphrase')
     }
 

--- a/core/src/test/groovy/org/hidetake/groovy/ssh/core/settings/ToStringPropertiesSpec.groovy
+++ b/core/src/test/groovy/org/hidetake/groovy/ssh/core/settings/ToStringPropertiesSpec.groovy
@@ -1,0 +1,132 @@
+package org.hidetake.groovy.ssh.core.settings
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ToStringPropertiesSpec extends Specification {
+
+    static class ExampleSettings implements ToStringProperties {
+        String name
+        Integer count
+    }
+
+    static class SecretSettings implements ToStringProperties {
+        String user
+        String password
+        final toString__password() { '...' }
+    }
+
+    static class ConstantSettings implements ToStringProperties {
+        String description
+        final constValue = 'constant'
+        final toString__constValue() {}
+    }
+
+    static class CompositeSettings implements ToStringProperties {
+        @Delegate
+        ExampleSettings exampleSettings = new ExampleSettings()
+
+        @Delegate
+        SecretSettings secretSettings = new SecretSettings()
+
+        @Delegate
+        ConstantSettings constantSettings = new ConstantSettings()
+    }
+
+    def "toString should contains each key and value of properties"() {
+        given:
+        def settings = new ExampleSettings(name: 'foo', count: 1000)
+
+        when:
+        def string = settings.toString()
+
+        then:
+        string in ['{count=1000, name=foo}', '{name=foo, count=1000}']
+    }
+
+    def "toString should exclude keys if each value is null"() {
+        given:
+        def settings = new ExampleSettings(name: 'foo')
+
+        when:
+        def string = settings.toString()
+
+        then:
+        string == '{name=foo}'
+    }
+
+    @Unroll
+    def "toString should use formatter if defined"() {
+        given:
+        def settings = new SecretSettings(user: 'foo', password: password)
+
+        when:
+        def string = settings.toString()
+
+        then:
+        string == mapString
+
+        where:
+        password | mapString
+        'SECRET' | '{password=..., user=foo}'
+        ''       | '{password=..., user=foo}'
+        null     | '{user=foo}'
+    }
+
+    def "toString should exclude key if formatter returns null"() {
+        given:
+        def settings = new ConstantSettings(description: 'foo')
+
+        when:
+        def string = settings.toString()
+
+        then:
+        string == '{description=foo}'
+    }
+
+    def "toString should contains each key and value of properties on delegated class"() {
+        given:
+        def settings = new CompositeSettings(name: 'foo', count: 1000)
+
+        expect:
+        settings.toString() in ['{count=1000, name=foo}', '{name=foo, count=1000}']
+        settings.exampleSettings.toString() in ['{count=1000, name=foo}', '{name=foo, count=1000}']
+    }
+
+    def "toString should exclude keys if each value is null on delegated class"() {
+        given:
+        def settings = new CompositeSettings(name: 'foo')
+
+        when:
+        def string = settings.toString()
+
+        then:
+        string == '{name=foo}'
+    }
+
+    @Unroll
+    def "toString should use formatter if defined on delegated class"() {
+        given:
+        def settings = new CompositeSettings(user: 'foo', password: password)
+
+        expect:
+        settings.toString() == mapString
+        settings.secretSettings.toString() == mapString
+
+        where:
+        password | mapString
+        'SECRET' | '{password=..., user=foo}'
+        ''       | '{password=..., user=foo}'
+        null     | '{user=foo}'
+    }
+
+    def "toString should exclude key if formatter returns null on delegated class"() {
+        given:
+        def settings = new CompositeSettings(name: 'foo')
+
+        expect:
+        settings.toString() == '{name=foo}'
+        settings.exampleSettings.toString() == '{name=foo}'
+    }
+
+}


### PR DESCRIPTION
This improves readability of settings in console log.

e.g.

```
2016-03-23 21:30:46.724 DEBUG Using default settings: {keepAliveSec=60, dryRun=false, pty=false, encoding=UTF-8, retryCount=0, retryWaitSec=0, logging=slf4j, knownHosts=/.ssh/known_hosts, ignoreError=false, agent=false}
2016-03-23 21:30:46.731 DEBUG Using global settings: {}
2016-03-23 21:30:46.733 DEBUG Using per-service settings: {}
2016-03-23 21:30:46.758 DEBUG Running 1 session(s) with {keepAliveSec=60, dryRun=false, pty=false, encoding=UTF-8, retryCount=0, retryWaitSec=0, logging=slf4j, knownHosts=/.ssh/known_hosts, ignoreError=false, agent=false}
...
2016-03-23 21:30:50.094 DEBUG Executing command on tester: java -jar gssh.jar --version: {ignoreError=false, pty=false, encoding=UTF-8, logging=slf4j}
```
