### PR TITLE
Improve most settings can be set per remote

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
@@ -24,7 +24,11 @@ import static org.hidetake.groovy.ssh.util.Utility.retry
 class ConnectionManager {
     protected static final LOCALHOST = '127.0.0.1'
 
+    /**
+     * Settings with default, global and per-service.
+     */
     private final ConnectionSettings connectionSettings
+
     private final List<Connection> connections = []
 
     @Lazy

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/Remote.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/Remote.groovy
@@ -1,8 +1,7 @@
 package org.hidetake.groovy.ssh.core
 
 import groovy.transform.EqualsAndHashCode
-import org.hidetake.groovy.ssh.connection.ConnectionSettings
-import org.hidetake.groovy.ssh.extension.settings.SudoSettings
+import org.hidetake.groovy.ssh.core.settings.CompositeSettings
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -10,10 +9,9 @@ import java.util.concurrent.atomic.AtomicInteger
  * Represents a remote host.
  *
  * @author Hidetake Iwata
- *
  */
 @EqualsAndHashCode(includes = 'name')
-class Remote implements ConnectionSettings, SudoSettings {
+class Remote implements CompositeSettings {
     /**
      * Name of this instance.
      */
@@ -24,21 +22,16 @@ class Remote implements ConnectionSettings, SudoSettings {
         assert name
     }
 
-    def Remote(Map<String, Object> settings) {
-        name = settings.name ?: "Remote${sequenceForAutoNaming.incrementAndGet()}"
-        settings.findAll { key, value ->
+    def Remote(Map<String, Object> settingsMap) {
+        name = settingsMap.name ?: "Remote${sequenceForAutoNaming.incrementAndGet()}"
+        settingsMap.findAll { key, value ->
             key != 'name'
         }.each { key, value ->
             setProperty(key, value)
         }
     }
 
-    private static final AtomicInteger sequenceForAutoNaming = new AtomicInteger()
-
-    /**
-     * Port.
-     */
-    int port = 22
+    private static final sequenceForAutoNaming = new AtomicInteger()
 
     /**
      * Remote host.
@@ -46,10 +39,19 @@ class Remote implements ConnectionSettings, SudoSettings {
     String host
 
     /**
+     * Port.
+     */
+    int port = 22
+
+    /**
      * Roles.
      */
-    final List<String> roles = []
+    final Set<String> roles = []
 
+    /**
+     * Add the role.
+     * @param role
+     */
     void role(String role) {
         assert role != null, 'role should be set'
         roles.add(role)

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/RunHandler.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/RunHandler.groovy
@@ -1,6 +1,6 @@
 package org.hidetake.groovy.ssh.core
 
-import org.hidetake.groovy.ssh.core.settings.CompositeSettings
+import org.hidetake.groovy.ssh.core.settings.PerServiceSettings
 import org.hidetake.groovy.ssh.session.Plan
 import org.hidetake.groovy.ssh.session.SessionHandler
 
@@ -15,7 +15,7 @@ class RunHandler {
     /**
      * Per service settings.
      */
-    final CompositeSettings settings = new CompositeSettings.With()
+    final settings = new PerServiceSettings()
 
     /**
      * Sessions added in the closure of {@link Service#run(groovy.lang.Closure)}.
@@ -25,9 +25,9 @@ class RunHandler {
     /**
      * Configure per service settings.
      *
-     * @param closure closure for {@link CompositeSettings}
+     * @param closure closure for {@link PerServiceSettings}
      */
-    void settings(@DelegatesTo(CompositeSettings) Closure closure) {
+    void settings(@DelegatesTo(PerServiceSettings) Closure closure) {
         assert closure, 'closure must be given'
         callWithDelegate(closure, settings)
     }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/Service.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/Service.groovy
@@ -4,7 +4,7 @@ import groovy.util.logging.Slf4j
 import org.hidetake.groovy.ssh.core.container.ContainerBuilder
 import org.hidetake.groovy.ssh.core.container.ProxyContainer
 import org.hidetake.groovy.ssh.core.container.RemoteContainer
-import org.hidetake.groovy.ssh.core.settings.CompositeSettings
+import org.hidetake.groovy.ssh.core.settings.GlobalSettings
 import org.hidetake.groovy.ssh.session.Executor
 
 import static org.hidetake.groovy.ssh.util.Utility.callWithDelegate
@@ -29,7 +29,7 @@ class Service {
     /**
      * Global settings.
      */
-    final CompositeSettings settings = new CompositeSettings.With()
+    final settings = new GlobalSettings()
 
     /**
      * Configure the container of remote hosts.
@@ -58,7 +58,7 @@ class Service {
      *
      * @param closure
      */
-    void settings(@DelegatesTo(CompositeSettings) Closure closure) {
+    void settings(@DelegatesTo(GlobalSettings) Closure closure) {
         assert closure, 'closure must be given'
         callWithDelegate(closure, settings)
     }
@@ -74,11 +74,7 @@ class Service {
         def handler = new RunHandler()
         callWithDelegate(closure, handler)
 
-        log.debug("Using default settings: $CompositeSettings.With.DEFAULT")
-        log.debug("Using global settings: $settings")
-        log.debug("Using per-service settings: $handler.settings")
-        def executor = new Executor(new CompositeSettings.With(CompositeSettings.With.DEFAULT, settings, handler.settings))
-
+        def executor = new Executor(settings, handler.settings)
         def results = executor.execute(handler.sessions)
         results.empty ? null : results.last()
     }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/GlobalSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/GlobalSettings.groovy
@@ -1,0 +1,9 @@
+package org.hidetake.groovy.ssh.core.settings
+
+/**
+ * A global settings.
+ *
+ * @author Hidetake Iwata
+ */
+class GlobalSettings extends CompositeSettings.With {
+}

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/PerServiceSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/settings/PerServiceSettings.groovy
@@ -1,0 +1,9 @@
+package org.hidetake.groovy.ssh.core.settings
+
+/**
+ * Per-service settings.
+ *
+ * @author Hidetake Iwata
+ */
+class PerServiceSettings extends CompositeSettings.With {
+}

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/extension/BackgroundCommand.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/extension/BackgroundCommand.groovy
@@ -46,7 +46,7 @@ trait BackgroundCommand implements SessionExtension {
         assert commandLine, 'commandLine must be given'
         assert map != null, 'map must not be null'
 
-        def settings = new CommandSettings.With(globalSettings, new CommandSettings.With(map))
+        def settings = new CommandSettings.With(mergedSettings, new CommandSettings.With(map))
         def command = operations.command(settings, commandLine)
 
         command.startAsync { int exitStatus ->
@@ -69,7 +69,7 @@ trait BackgroundCommand implements SessionExtension {
         assert callback, 'callback must be given'
         assert map != null, 'map must not be null'
 
-        def settings = new CommandSettings.With(globalSettings, new CommandSettings.With(map))
+        def settings = new CommandSettings.With(mergedSettings, new CommandSettings.With(map))
         def operation = operations.command(settings, commandLine)
 
         def lines = [] as List<String>

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/extension/Command.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/extension/Command.groovy
@@ -65,7 +65,7 @@ trait Command implements SessionExtension {
         assert commandLine, 'commandLine must be given'
         assert map != null, 'map must not be null'
 
-        def settings = new CommandSettings.With(globalSettings, new CommandSettings.With(map))
+        def settings = new CommandSettings.With(mergedSettings, new CommandSettings.With(map))
         def operation = operations.command(settings, commandLine)
 
         def lines = [] as List<String>

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/extension/Shell.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/extension/Shell.groovy
@@ -20,7 +20,7 @@ trait Shell implements SessionExtension {
     void shell(HashMap map) {
         assert map != null, 'map must not be null'
 
-        def settings = new ShellSettings.With(globalSettings, new ShellSettings.With(map))
+        def settings = new ShellSettings.With(mergedSettings, new ShellSettings.With(map))
         def operation = operations.shell(settings)
 
         def exitStatus = operation.startSync()

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/extension/Sudo.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/extension/Sudo.groovy
@@ -27,7 +27,7 @@ trait Sudo implements SessionExtension {
      */
     String executeSudo(String command) {
         assert command, 'command must be given'
-        def executor = new SudoExecutor(operations, globalSettings, new SudoCommandSettings())
+        def executor = new SudoExecutor(operations, mergedSettings, new SudoCommandSettings())
         executor.execute(command)
     }
 
@@ -42,7 +42,7 @@ trait Sudo implements SessionExtension {
     String executeSudo(HashMap settings, String command) {
         assert command, 'command must be given'
         assert settings != null, 'settings must not be null'
-        def executor = new SudoExecutor(operations, globalSettings, new SudoCommandSettings(settings))
+        def executor = new SudoExecutor(operations, mergedSettings, new SudoCommandSettings(settings))
         executor.execute(command)
     }
 
@@ -91,13 +91,12 @@ trait Sudo implements SessionExtension {
         final CommandSettings commandSettings
         final SudoSettings sudoSettings
 
-        def SudoExecutor(Operations operations1, CompositeSettings globalSettings, SudoCommandSettings perMethodSettings) {
+        def SudoExecutor(Operations operations1, CompositeSettings mergedSettings, SudoCommandSettings perMethodSettings) {
             operations = operations1
-            commandSettings = new CommandSettings.With(globalSettings, perMethodSettings)
+            commandSettings = new CommandSettings.With(mergedSettings, perMethodSettings)
             sudoSettings = new SudoSettings.With(
-                    CompositeSettings.With.DEFAULT,
                     new SudoSettings.With(sudoPassword: operations.remote.password),
-                    operations.remote,
+                    mergedSettings,
                     perMethodSettings
             )
         }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionExtension.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionExtension.groovy
@@ -34,8 +34,8 @@ trait SessionExtension {
     abstract Operations getOperations()
 
     /**
-     * Return the current global settings.
+     * Return the settings with default, global, per-service and per-remote.
      * Only for DSL extensions, do not use from the script.
      */
-    abstract CompositeSettings getGlobalSettings()
+    abstract CompositeSettings getMergedSettings()
 }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionHandler.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionHandler.groovy
@@ -14,13 +14,16 @@ import org.hidetake.groovy.ssh.operation.SftpOperations
  */
 @Slf4j
 class SessionHandler implements CoreExtensions {
-    private final Operations operations
+    final Operations operations
 
-    private final CompositeSettings globalSettings
+    /**
+     * Settings with default, global, per-service and per-remote.
+     */
+    final CompositeSettings mergedSettings
 
-    static def create(Operations operations, CompositeSettings globalSettings) {
-        def handler = new SessionHandler(operations, globalSettings)
-        globalSettings.extensions.inject(handler) { applied, extension ->
+    static def create(Operations operations, CompositeSettings mergedSettings) {
+        def handler = new SessionHandler(operations, mergedSettings)
+        mergedSettings.extensions.inject(handler) { applied, extension ->
             if (extension instanceof Class) {
                 log.debug("Applying extension: $extension")
                 applied.withTraits(extension)
@@ -37,19 +40,9 @@ class SessionHandler implements CoreExtensions {
         }
     }
 
-    private def SessionHandler(Operations operations1, CompositeSettings globalSettings1) {
+    private def SessionHandler(Operations operations1, CompositeSettings mergedSettings1) {
         operations = operations1
-        globalSettings = globalSettings1
-    }
-
-    @Override
-    Operations getOperations() {
-        operations
-    }
-
-    @Override
-    CompositeSettings getGlobalSettings() {
-        globalSettings
+        mergedSettings = mergedSettings1
     }
 
     @Override

--- a/docs/src/docs/asciidoc/user-guide.adoc
+++ b/docs/src/docs/asciidoc/user-guide.adoc
@@ -768,11 +768,11 @@ Some settings can be set in global and overridden by each `ssh.run` method, remo
 .List of settings
 [options="header,autowidth"]
 |===
-|Settings               | Global | Each `ssh.run` | Each remote | Each method
+|Settings               | Global | Per `ssh.run`  | Per remote  | Per method
 |Connection settings    | x      | x              | x           | -
-|Command settings       | x      | x              | -           | x
-|Shell settings         | x      | x              | -           | x
-|Sudo settings          | -      | -              | x           | x
+|Command settings       | x      | x              | x           | x
+|Shell settings         | x      | x              | x           | x
+|Sudo settings          | x      | x              | x           | x
 |Remote settings        | -      | -              | x           | -
 |Proxy settings         | -      | -              | x           | -
 |Local port forwarding settings  | -      | -     | -           | x
@@ -810,6 +810,8 @@ remotes {
     host = '192.168.1.101'
     user = 'jenkins'
     identity = file('id_rsa_jenkins')
+    // overrides global settings
+    agentForwarding = true
   }
 }
 ```


### PR DESCRIPTION
This improves per-remote settings to include command, shell and sudo settings. We can set not only connection settings such as `pty` or `sudoPath` in the `remote` closure as follows.

```groovy
remotes {
  testServer {
    host = 'localhost'
    user = 'user'
    pty = true
    agentForwarding = true
    sudoPath = '/usr/local/bin/sudo'
  }
}
```
