### PR TITLE
Add jschLog setting to switch JSch verbose log

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
@@ -103,8 +103,6 @@ class ConnectionManager {
         assert settings.identity instanceof File || settings.identity instanceof String || settings.identity == null,
                 'identity must be a File, String or null'
 
-        JSch.logger = JSchLogger.instance
-
         retry(settings.retryCount, settings.retryWaitSec) {
             def jsch = new JSch()
             def session = jsch.getSession(settings.user, host, port)

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/Executor.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/Executor.groovy
@@ -1,7 +1,9 @@
 package org.hidetake.groovy.ssh.session
 
+import com.jcraft.jsch.JSch
 import groovy.util.logging.Slf4j
 import org.hidetake.groovy.ssh.connection.ConnectionManager
+import org.hidetake.groovy.ssh.connection.JSchLogger
 import org.hidetake.groovy.ssh.core.settings.CompositeSettings
 import org.hidetake.groovy.ssh.core.settings.GlobalSettings
 import org.hidetake.groovy.ssh.core.settings.PerServiceSettings
@@ -38,6 +40,9 @@ class Executor {
         log.debug("Using global settings: $globalSettings")
         log.debug("Using per-service settings: $perServiceSettings")
         def mergedSettings = new CompositeSettings.With(CompositeSettings.With.DEFAULT, globalSettings, perServiceSettings)
+
+        // not thread safe
+        JSch.logger = mergedSettings.jschLog ? JSchLogger.instance : null
 
         if (mergedSettings.dryRun) {
             dryRun(plans, mergedSettings)

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionSettings.groovy
@@ -17,6 +17,11 @@ trait SessionSettings {
     Boolean dryRun
 
     /**
+     * JSch logging flag.
+     */
+    Boolean jschLog
+
+    /**
      * Extensions for {@link org.hidetake.groovy.ssh.session.SessionHandler}.
      */
     List extensions = []
@@ -41,6 +46,7 @@ trait SessionSettings {
 
         static final SessionSettings DEFAULT = new SessionSettings.With(
                 dryRun: false,
+                jschLog: false,
                 extensions: [],
         )
     }

--- a/docs/src/docs/asciidoc/user-guide.adoc
+++ b/docs/src/docs/asciidoc/user-guide.adoc
@@ -434,6 +434,7 @@ Following settings can be set in global:
 |===
 |Key            | Type                  | Description
 |`dryRun`       | Boolean               | Dry run flag. If this is true, no actual connection or operation is performed. Defaults to false.
+|`jschLog`      | Boolean               | JSch logging flag. If this is true, verbose log of JSch is shown. Defaults to false.
 |`extensions`   | List of Trait or Map  | DSL extensions. Defaults to an empty list.
 |===
 


### PR DESCRIPTION
This adds `jschLog` setting to switch JSch verbose log. Defaults to false.