### PR TITLE
Add setting of user authentication methods

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
@@ -106,7 +106,7 @@ class ConnectionManager {
         retry(settings.retryCount, settings.retryWaitSec) {
             def jsch = new JSch()
             def session = jsch.getSession(settings.user, host, port)
-            session.setConfig('PreferredAuthentications', 'publickey,keyboard-interactive,password')
+            session.setConfig('PreferredAuthentications', settings.authentications.join(','))
             session.setServerAliveInterval(settings.keepAliveSec * 1000)
 
             if (settings.knownHosts == ConnectionSettings.Constants.allowAnyHosts) {

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionSettings.groovy
@@ -71,6 +71,7 @@ trait ConnectionSettings implements UserAuthentication {
 
         static final ConnectionSettings DEFAULT = new ConnectionSettings.With(
                 user: null,
+                authentications: ['publickey', 'keyboard-interactive', 'password'],
                 password: null,
                 identity: null,
                 passphrase: null,

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/UserAuthentication.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/UserAuthentication.groovy
@@ -7,6 +7,11 @@ trait UserAuthentication {
     String user
 
     /**
+     * Authentication methods.
+     */
+    List<String> authentications
+
+    /**
      * Password.
      * Leave as null if the password authentication is not needed.
      */

--- a/docs/src/docs/asciidoc/user-guide.adoc
+++ b/docs/src/docs/asciidoc/user-guide.adoc
@@ -173,6 +173,7 @@ Also following settings can be set in a remote closure.
 |===
 |Key            | Type              | Description
 |`user`         | String, Mandatory | User name.
+|`authentications` | List of String | Authentication methods in order. Defaults to `publickey`, `keyboard-interactive` and `password`.
 |`password`     | String            | A password for password authentication. Defaults to null (no password authentication).
 |`identity`     | File or String    | A private key for public-key authentication. This can be a key File or key content String. Defaults to null (no public-key authentication).
 |`passphrase`   | String            | A pass-phrase of the private key. Defaults to null (no pass-phrase).


### PR DESCRIPTION
This adds `authentications` to connection settings for custom order of authentication methods. See #141.