### PR TITLE
Escape command args if list of strings is given

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/Command.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/Command.groovy
@@ -8,65 +8,48 @@ import org.hidetake.groovy.ssh.session.SessionExtension
 
 /**
  * Provides the blocking command execution.
+ * Each method blocks until channel is closed.
  *
  * @author Hidetake Iwata
  */
 trait Command implements SessionExtension {
-    /**
-     * Performs an execution operation.
-     * This method blocks until channel is closed.
-     *
-     * @param commandLine
-     * @return output value of the commandLine
-     */
     String execute(String commandLine) {
-        assert commandLine, 'commandLine must be given'
         execute([:], commandLine)
     }
 
-    /**
-     * Performs an execution operation.
-     * This method blocks until channel is closed.
-     *
-     * @param commandLine
-     * @param callback closure called with an output value of the commandLine
-     * @return output value of the commandLine
-     */
+    String execute(List<String> commandLineArgs) {
+        execute([:], commandLineArgs)
+    }
+
     void execute(String commandLine, Closure callback) {
-        assert commandLine, 'commandLine must be given'
-        assert callback, 'callback must be given'
         execute([:], commandLine, callback)
     }
 
-    /**
-     * Performs an execution operation.
-     * This method blocks until channel is closed.
-     *
-     * @param map execution settings
-     * @param commandLine
-     * @param callback closure called with an output value of the commandLine
-     * @return output value of the commandLine
-     */
+    void execute(List<String> commandLineArgs, Closure callback) {
+        execute([:], commandLineArgs, callback)
+    }
+
     void execute(HashMap map, String commandLine, Closure callback) {
-        assert commandLine, 'commandLine must be given'
         assert callback, 'callback must be given'
-        assert map != null, 'settings must not be null'
         callback.call(execute(map, commandLine))
     }
 
-    /**
-     * Performs an execution operation.
-     * This method blocks until channel is closed.
-     *
-     * @param map execution settings
-     * @param commandLine
-     * @return output value of the commandLine
-     */
+    void execute(HashMap map, List<String> commandLineArgs, Closure callback) {
+        assert callback, 'callback must be given'
+        callback.call(execute(map, commandLineArgs))
+    }
+
     String execute(HashMap map, String commandLine) {
         assert commandLine, 'commandLine must be given'
         assert map != null, 'map must not be null'
         def settings = new CommandSettings.With(mergedSettings, new CommandSettings.With(map))
         Helper.execute(operations, settings, commandLine)
+    }
+
+    String execute(HashMap map, List<String> commandLineArgs) {
+        assert commandLineArgs, 'commandLineArgs must be given'
+        assert map != null, 'map must not be null'
+        execute(map, Escape.escape(commandLineArgs))
     }
 
     private static class Helper {

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/Escape.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/Escape.groovy
@@ -1,0 +1,20 @@
+package org.hidetake.groovy.ssh.session.execution
+
+/**
+ * Shell escape utility.
+ *
+ * @author Hidetake Iwata
+ */
+class Escape {
+
+    /**
+     * Escape command arguments.
+     * This method quotes each argument with single-quote.
+     * @param arguments
+     * @return
+     */
+    static String escape(List<String> arguments) {
+        arguments.collect { /'${it.replaceAll(~/'/, /'\\''/)}'/ }.join(/ /)
+    }
+
+}

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/Sudo.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/Sudo.groovy
@@ -4,63 +4,51 @@ import org.hidetake.groovy.ssh.session.SessionExtension
 
 /**
  * An extension class of sudo command execution.
+ * Each method performs a sudo operation, explicitly providing password for the sudo user.
+ * It blocks until channel is closed.
  *
  * @author Hidetake Iwata
  */
 trait Sudo implements SessionExtension {
-    /**
-     * Performs a sudo operation, explicitly providing password for the sudo user.
-     * This method blocks until channel is closed.
-     *
-     * @param command
-     * @return output value of the command
-     */
-    String executeSudo(String command) {
-        assert command, 'command must be given'
+    String executeSudo(String commandLine) {
+        assert commandLine, 'commandLine must be given'
         def helper = new SudoHelper(operations, mergedSettings, new SudoHelper.SudoCommandSettings())
-        helper.execute(command)
+        helper.execute(commandLine)
     }
 
-    /**
-     * Performs a sudo operation, explicitly providing password for the sudo user.
-     * This method blocks until channel is closed.
-     *
-     * @param settings execution settings
-     * @param command
-     * @return output value of the command
-     */
-    String executeSudo(HashMap settings, String command) {
-        assert command, 'command must be given'
+    String executeSudo(List<String> commandLineArgs) {
+        executeSudo(Escape.escape(commandLineArgs))
+    }
+
+    String executeSudo(HashMap settings, String commandLine) {
+        assert commandLine, 'commandLine must be given'
         assert settings != null, 'settings must not be null'
         def helper = new SudoHelper(operations, mergedSettings, new SudoHelper.SudoCommandSettings(settings))
-        helper.execute(command)
+        helper.execute(commandLine)
     }
 
-    /**
-     * Performs a sudo operation, explicitly providing password for the sudo user.
-     * This method blocks until channel is closed.
-     *
-     * @param command
-     * @param callback closure called with an output value of the command
-     */
-    void executeSudo(String command, Closure callback) {
-        assert command, 'command must be given'
+    String executeSudo(HashMap settings, List<String> commandLineArgs) {
+        executeSudo(settings, Escape.escape(commandLineArgs))
+    }
+
+    void executeSudo(String commandLine, Closure callback) {
+        assert commandLine, 'commandLine must be given'
         assert callback, 'callback must be given'
-        callback.call(executeSudo(command))
+        callback.call(executeSudo(commandLine))
     }
 
-    /**
-     * Performs a sudo operation, explicitly providing password for the sudo user.
-     * This method blocks until channel is closed.
-     *
-     * @param settings execution settings
-     * @param command
-     * @param callback closure called with an output value of the command
-     */
-    void executeSudo(HashMap settings, String command, Closure callback) {
-        assert command, 'command must be given'
+    void executeSudo(List<String> commandLineArgs, Closure callback) {
+        executeSudo(Escape.escape(commandLineArgs), callback)
+    }
+
+    void executeSudo(HashMap settings, String commandLine, Closure callback) {
+        assert commandLine, 'commandLine must be given'
         assert callback, 'callback must be given'
         assert settings != null, 'settings must not be null'
-        callback.call(executeSudo(settings, command))
+        callback.call(executeSudo(settings, commandLine))
+    }
+
+    void executeSudo(HashMap settings, List<String> commandLineArgs, Closure callback) {
+        executeSudo(settings, Escape.escape(commandLineArgs), callback)
     }
 }

--- a/core/src/test/groovy/org/hidetake/groovy/ssh/session/execution/EscapeSpec.groovy
+++ b/core/src/test/groovy/org/hidetake/groovy/ssh/session/execution/EscapeSpec.groovy
@@ -1,0 +1,23 @@
+package org.hidetake.groovy.ssh.session.execution
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class EscapeSpec extends Specification {
+
+    @Unroll
+    def "escape() should return escaped string when #args"() {
+        when:
+        def escaped = Escape.escape(args)
+
+        then:
+        escaped == expected
+
+        where:
+        args    | expected
+        []      | ''
+        ['']    | /''/
+        [/hello/, /!"#$%&'()*+,-.\/:;<=>?@[\]^_`{|}~/]  | /'hello' '!"#$%&'\''()*+,-.\/:;<=>?@[\]^_`{|}~'/
+    }
+
+}

--- a/docs/src/docs/asciidoc/user-guide.adoc
+++ b/docs/src/docs/asciidoc/user-guide.adoc
@@ -609,13 +609,16 @@ Call the `execute` method with a command to execute.
 [source,groovy]
 ----
 execute 'sudo service httpd reload'
+
+// with settings
+execute 'sudo service httpd reload', pty: true
 ----
 
-The method can be called with operation settings.
+The method escapes command arguments if a list of strings is given.
 
 [source,groovy]
 ----
-execute 'sudo service httpd reload', pty: true
+execute(['perl', '-e', /print 'current: ', time, "\n"/])
 ----
 
 The method waits until the command is completed and returns a result from standard output of the command.
@@ -695,7 +698,7 @@ Call the `executeBackground` method with a command to execute in background.
 ----
 executeBackground 'sudo service httpd reload'
 
-// also can be called with operation settings
+// with settings
 executeBackground 'sudo service httpd reload', pty: true
 ----
 
@@ -715,6 +718,13 @@ session(remotes.web01) {
     executeBackground "ping -c 1 -w 1 192.168.1.$lastOctet"
   }
 }
+----
+
+The method escapes command arguments if a list of strings is given.
+
+[source,groovy]
+----
+executeBackground(['perl', '-e', /print 'current: ', time, "\n"/])
 ----
 
 A result can be retrieved as an argument if a closure is given.
@@ -759,6 +769,13 @@ Line separators are converted to the platform native.
 ----
 def result = executeSudo 'service httpd status'
 println result
+----
+
+The method escapes command arguments if a list of strings is given.
+
+[source,groovy]
+----
+executeSudo(['perl', '-e', /print 'current: ', time, "\n"/])
 ----
 
 A result can be retrieved as an argument if a closure is given.

--- a/os-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/os/CommandSpec.groovy
+++ b/os-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/os/CommandSpec.groovy
@@ -33,12 +33,24 @@ class CommandSpec extends Specification {
         when:
         def r = ssh.run {
             session(ssh.remotes.testServer) {
-                execute "expr $x + $y"
+                execute(['expr', x, '+', y]*.toString())
             }
         } as int
 
         then:
         r == (x + y)
+    }
+
+    def 'should escape command line arguments'() {
+        when:
+        def r = ssh.run {
+            session(ssh.remotes.testServer) {
+                execute(['perl', '-e', /print 'current: ', time, "\n"/])
+            }
+        }
+
+        then:
+        r =~ /current: \d+/
     }
 
     def 'should execute commands by multi-line string'() {

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/CommandSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/CommandSpec.groovy
@@ -102,6 +102,17 @@ class CommandSpec extends Specification {
         resultActual == 'something output'
     }
 
+    def "execute should escape arguments if string list is given"() {
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                execute([/this 'should' be escaped/])
+            }
+        }
+
+        then: 1 * server.commandFactory.createCommand(/'this '\''should'\'' be escaped'/) >> commandWithExit(0)
+    }
+
     @Unroll
     def "execute should return output of the command: #description"() {
         when:
@@ -126,7 +137,7 @@ class CommandSpec extends Specification {
         'lines with line sep'  | 'some result\nsecond line\n' | "some result${NL}second line"
     }
 
-    def "execute can return value via callback closure"() {
+    def "execute should return value via callback closure"() {
         given:
         def resultActual
 
@@ -146,7 +157,26 @@ class CommandSpec extends Specification {
         resultActual == 'something output'
     }
 
-    def "execute can return value via callback with setting"() {
+    def "execute should escape arguments if string list is given and return value via callback closure"() {
+        given:
+        def resultActual
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                execute(["echo", /this 'should' be escaped/]) { result ->
+                    resultActual = result
+                }
+            }
+        }
+
+        then: 1 * server.commandFactory.createCommand(/'echo' 'this '\''should'\'' be escaped'/) >> commandWithExit(0, 'something output')
+
+        then:
+        resultActual == 'something output'
+    }
+
+    def "execute should return value via callback with setting"() {
         given:
         def resultActual
 
@@ -161,6 +191,26 @@ class CommandSpec extends Specification {
 
         then:
         1 * server.commandFactory.createCommand('somecommand') >> commandWithExit(0, 'something output')
+
+        then:
+        resultActual == 'something output'
+    }
+
+    def "execute should escape arguments if string list is given return value via callback with setting"() {
+        given:
+        def resultActual
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                execute(['echo', /this 'should' be escaped/], pty: true) { result ->
+                    resultActual = result
+                }
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(/'echo' 'this '\''should'\'' be escaped'/) >> commandWithExit(0, 'something output')
 
         then:
         resultActual == 'something output'

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/SudoSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/SudoSpec.groovy
@@ -175,6 +175,23 @@ class SudoSpec extends Specification {
         resultActual == 'something output'
     }
 
+    def "executeSudo should escape arguments if string list is given"() {
+        when:
+        def resultActual = ssh.run {
+            session(ssh.remotes.testServer) {
+                executeSudo([/this 'should' be escaped/])
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(_) >> { String command ->
+            commandWithSudoPrompt(command, 'sudo', /'this '\''should'\'' be escaped'/, 'somepassword', 0, 'something output')
+        }
+
+        then:
+        resultActual == 'something output'
+    }
+
     def "executeSudo should accept sudo password by method settings"() {
         when:
         ssh.run {
@@ -275,6 +292,28 @@ class SudoSpec extends Specification {
         resultActual == 'something output'
     }
 
+    def "executeSudo should escape arguments if string list is given and return value via callback closure"() {
+        given:
+        def resultActual
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeSudo(["echo", /this 'should' be escaped/]) { result ->
+                    resultActual = result
+                }
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(_) >> { String command ->
+            commandWithSudoPrompt(command, 'sudo', /'echo' 'this '\''should'\'' be escaped'/, 'somepassword', 0, 'something output')
+        }
+
+        then:
+        resultActual == 'something output'
+    }
+
     def "executeSudo can return value via callback setting"() {
         given:
         def resultActual
@@ -291,6 +330,28 @@ class SudoSpec extends Specification {
         then:
         1 * server.commandFactory.createCommand(_) >> { String command ->
             commandWithSudoPrompt(command, 'sudo', 'somecommand', 'somepassword', 0, 'something output')
+        }
+
+        then:
+        resultActual == 'something output'
+    }
+
+    def "executeSudo should escape arguments if string list is given and return value via callback closure with settings"() {
+        given:
+        def resultActual
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeSudo(['echo', /this 'should' be escaped/], pty: true) { result ->
+                    resultActual = result
+                }
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand(_) >> { String command ->
+            commandWithSudoPrompt(command, 'sudo', /'echo' 'this '\''should'\'' be escaped'/, 'somepassword', 0, 'something output')
         }
 
         then:


### PR DESCRIPTION
This provides easy way to escape command line arguments.

```groovy
execute(['perl', '-e', /print 'current: ', time, "\n"/])
```

Originally https://github.com/int128/gradle-ssh-plugin/issues/165