### PR TITLE
Use public key authentication for sudo spec

### DIFF
--- a/os-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/os/UserAuthenticationSpec.groovy
+++ b/os-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/os/UserAuthenticationSpec.groovy
@@ -95,7 +95,7 @@ class UserAuthenticationSpec extends Specification {
         when:
         ssh.run {
             session(ssh.remotes.RequireAgent) {
-                execute "ssh localhost id"
+                execute "ssh -o StrictHostKeyChecking=no localhost id"
             }
         }
 
@@ -108,7 +108,7 @@ class UserAuthenticationSpec extends Specification {
         when:
         def id = ssh.run {
             session(ssh.remotes.RequireAgent) {
-                execute "ssh localhost id", agentForwarding: true
+                execute "ssh -o StrictHostKeyChecking=no localhost id", agentForwarding: true
             }
         }
 


### PR DESCRIPTION
This improves OS integration test should run on initial state of EC2 server. Sudo spec may fail on most environment due to disabled password authentication.