### PR TITLE
Skip lecture message from sudo result

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/SudoHelper.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/SudoHelper.groovy
@@ -45,6 +45,7 @@ class SudoHelper {
                     }
                     when(line: _, from: standardOutput) {
                         log.info("Success sudo authentication on $operations.remote.name")
+                        lines.clear()
                         lines << it
 
                         when(line: _, from: standardOutput) {


### PR DESCRIPTION
This fixes sudo implementation to exclude the lecture message like following from result.

```
We trust you have received the usual lecture from the local System
Administrator. It usually boils down to these three things:

    #1) Respect the privacy of others.
    #2) Think before you type.
    #3) With great power comes great responsibility.

```
