### PR TITLE
Fix remove() fails if recursively

### DIFF
--- a/os-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/os/SftpSpec.groovy
+++ b/os-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/os/SftpSpec.groovy
@@ -1,9 +1,30 @@
 package org.hidetake.groovy.ssh.test.os
 
+import static org.hidetake.groovy.ssh.test.os.Fixture.remoteTmpPath
+
 /**
  * Check if file transfer works with SFTP subsystem of OpenSSH.
  *
  * @author Hidetake Iwata
  */
 class SftpSpec extends AbstractFileTransferSpec {
+
+    def 'remove() should delete a directory recursively'() {
+        given:
+        def remoteDir = remoteTmpPath()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.Default) {
+                execute "mkdir -vp $remoteDir/foo/bar"
+                execute "date > $remoteDir/foo/bar/baz"
+                remove remoteDir
+                execute "test ! -d $remoteDir"
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
 }

--- a/server-integration-test/src/main/groovy/org/hidetake/groovy/ssh/test/server/Helper.groovy
+++ b/server-integration-test/src/main/groovy/org/hidetake/groovy/ssh/test/server/Helper.groovy
@@ -1,9 +1,0 @@
-package org.hidetake.groovy.ssh.test.server
-
-class Helper {
-
-    static uuidgen() {
-        UUID.randomUUID().toString()
-    }
-
-}


### PR DESCRIPTION
This fixes bug https://github.com/int128/gradle-ssh-plugin/issues/253. Also improves `remove()` works on Gradle 1.x.