### PR TITLE
Update to JSch 0.1.53

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,7 +10,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.4'
     compile 'org.slf4j:slf4j-api:1.7.7'
-    compile 'com.jcraft:jsch:0.1.52'
+    compile 'com.jcraft:jsch:0.1.53'
     compile 'com.jcraft:jsch.agentproxy.connector-factory:0.0.7'
     compile 'com.jcraft:jsch.agentproxy.jsch:0.0.7'
 


### PR DESCRIPTION
This fixes the bug that the plugin does not work on OpenSSH 7.2 as https://github.com/int128/gradle-ssh-plugin/issues/259.

