### PR TITLE
Bump to Groovy 2.4.7

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.4'
+    compile 'org.codehaus.groovy:groovy-all:2.4.7'
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'com.jcraft:jsch:0.1.53'
     compile 'com.jcraft:jsch.agentproxy.connector-factory:0.0.7'


### PR DESCRIPTION
This bumps Groovy version and fixes the bug that Groovy compiler raises IllegalArgumentException if a trait has many (maybe 10 or more) properties: https://issues.apache.org/jira/browse/GROOVY-7387. Compiled classes may work on Groovy 2.4.4 that is bundled with Gradle.