### PR TITLE
Add inputStream setting for command or shell

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/Command.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/Command.groovy
@@ -32,6 +32,20 @@ class Command implements Operation {
         channel.agentForwarding = settings.agentForwarding
 
         interactions = new Interactions(channel.outputStream, channel.inputStream, channel.errStream, settings.encoding)
+        if (settings.inputStream) {
+            interactions.add {
+                standardInput.withStream {
+                    log.debug("Sending to standard input on command $connection.remote.name#$channel.id")
+                    try {
+                        standardInput << settings.inputStream
+                    } finally {
+                        if (settings.inputStream instanceof Closeable) {
+                            settings.inputStream.close()
+                        }
+                    }
+                }
+            }
+        }
         if (settings.outputStream) {
             interactions.pipe(Stream.StandardOutput, settings.outputStream)
         }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/CommandSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/CommandSettings.groovy
@@ -34,12 +34,18 @@ trait CommandSettings {
     LoggingMethod logging
 
     /**
-     * An output stream to forward the standard output.
+     * An input stream to send to the standard input.
+     * This should be a {@link InputStream}, {@code byte[]} or {@link String}.
+     */
+    def inputStream
+
+    /**
+     * An output stream to receive from the standard output.
      */
     OutputStream outputStream
 
     /**
-     * An output stream to forward the standard error.
+     * An output stream to receive from the standard error.
      */
     OutputStream errorStream
 

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/Shell.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/Shell.groovy
@@ -27,6 +27,20 @@ class Shell implements Operation {
         channelConnectionTimeoutSec = settings.timeoutSec
 
         interactions = new Interactions(channel.outputStream, channel.inputStream, settings.encoding)
+        if (settings.inputStream) {
+            interactions.add {
+                standardInput.withStream {
+                    log.debug("Sending to standard input on command $connection.remote.name#$channel.id")
+                    try {
+                        standardInput << settings.inputStream
+                    } finally {
+                        if (settings.inputStream instanceof Closeable) {
+                            settings.inputStream.close()
+                        }
+                    }
+                }
+            }
+        }
         if (settings.outputStream) {
             interactions.pipe(Stream.StandardOutput, settings.outputStream)
         }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/ShellSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/ShellSettings.groovy
@@ -34,7 +34,13 @@ trait ShellSettings {
     LoggingMethod logging
 
     /**
-     * An output stream to forward the standard output.
+     * An input stream to send to the standard input.
+     * This should be a {@link InputStream}, {@code byte[]} or {@link String}.
+     */
+    def inputStream
+
+    /**
+     * An output stream to receive from the standard output.
      */
     OutputStream outputStream
 

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/SudoSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/SudoSettings.groovy
@@ -15,6 +15,12 @@ trait SudoSettings {
      */
     String sudoPath
 
+    /**
+     * An input stream to send to the standard input.
+     * @see org.hidetake.groovy.ssh.operation.CommandSettings#inputStream
+     */
+    def inputStream
+
 
     @EqualsAndHashCode
     static class With implements SudoSettings, ToStringProperties {

--- a/docs/src/docs/asciidoc/user-guide.adoc
+++ b/docs/src/docs/asciidoc/user-guide.adoc
@@ -693,13 +693,17 @@ The method accepts following settings:
  If this is `none`, console logging is turned off.
  Defaults to `slf4j`.
 
+|`inputStream`
+|`InputStream`, `byte[]` or `String`
+|An input data to sent to the standard input of remote command. Defaults to null.
+
 |`outputStream`
 |`OutputStream`
-|If this is set, standard output of the remote command is sent to the stream. Defaults to null.
+|An output stream to receive from the standard output of remote command. Defaults to null.
 
 |`errorStream`
 |`OutputStream`
-|If this is set, standard error of the remote command is sent to the stream. Defaults to null.
+|An output stream to receive from the standard error of remote command. Defaults to null.
 
 |`encoding`
 |`String`
@@ -884,9 +888,13 @@ The method accepts following settings:
  If this is `none`, console logging is turned off.
  Defaults to `slf4j`.
 
+|`inputStream`
+|`InputStream`, `byte[]` or `String`
+|An input data to sent to the standard input of remote command. Defaults to null.
+
 |`outputStream`
 |`OutputStream`
-|If this is set, standard output of the remote command is sent to the stream. Defaults to null.
+|An output stream to receive from the standard output of remote command. Defaults to null.
 
 |`encoding`
 |`String`

--- a/os-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/os/CommandSpec.groovy
+++ b/os-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/os/CommandSpec.groovy
@@ -1,5 +1,6 @@
 package org.hidetake.groovy.ssh.test.os
 
+import org.codehaus.groovy.tools.Utilities
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import org.junit.Rule
@@ -225,6 +226,21 @@ expr $x + `cat $remoteA` > $remoteB
 
         then:
         resultFile.text.contains('hoge')
+    }
+
+    def 'should execute command via standard input'() {
+        when:
+        def actual = ssh.run {
+            session(ssh.remotes.Default) {
+                execute '/bin/sh', inputStream: '''#!/bin/sh
+echo 1
+echo 2
+'''
+            }
+        }
+
+        then:
+        actual == "1${Utilities.eol()}2"
     }
 
 }

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/BackgroundCommandSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/BackgroundCommandSpec.groovy
@@ -385,4 +385,28 @@ class BackgroundCommandSpec extends Specification {
         noExceptionThrown()
     }
 
+    @Unroll
+    def "executeBackground should send to standard input if given #input"() {
+        given:
+        def actual = new ByteArrayOutputStream()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeBackground 'somecommand', inputStream: input
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand('somecommand') >> command(0) {
+            actual << inputStream
+        }
+
+        then:
+        actual.toString() == 'some message'
+
+        where:
+        input << [new ByteArrayInputStream('some message'.bytes), 'some message', 'some message'.bytes]
+    }
+
 }

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/CommandSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/CommandSpec.groovy
@@ -366,4 +366,28 @@ class CommandSpec extends Specification {
         noExceptionThrown()
     }
 
+    @Unroll
+    def "execute should send to standard input if given #input"() {
+        given:
+        def actual = new ByteArrayOutputStream()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                execute 'somecommand', inputStream: input
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand('somecommand') >> command(0) {
+            actual << inputStream
+        }
+
+        then:
+        actual.toString() == 'some message'
+
+        where:
+        input << [new ByteArrayInputStream('some message'.bytes), 'some message', 'some message'.bytes]
+    }
+
 }

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ShellSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ShellSpec.groovy
@@ -210,4 +210,28 @@ class ShellSpec extends Specification {
         }
     }
 
+    @Unroll
+    def "shell should send stream to standard input if given #input"() {
+        given:
+        def actual = new ByteArrayOutputStream()
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                shell inputStream: input
+            }
+        }
+
+        then:
+        1 * server.shellFactory.create() >> command(0) {
+            actual << inputStream
+        }
+
+        then:
+        actual.toString() == 'some message'
+
+        where:
+        input << [new ByteArrayInputStream('some message'.bytes), 'some message', 'some message'.bytes]
+    }
+
 }


### PR DESCRIPTION
This adds the feature to send data to the standard input of command or shell via the `inputStream` setting.


### Steps to use the feature
1. Call execute, executeSudo or shell with inputStream. e.g. `execute inputStream: 'input for command'`


See https://github.com/int128/gradle-ssh-plugin/issues/249.
