### PR TITLE
Add executeScript method for script execution

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionExtensions.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/SessionExtensions.groovy
@@ -1,9 +1,6 @@
 package org.hidetake.groovy.ssh.session
 
-import org.hidetake.groovy.ssh.session.execution.BackgroundCommand
-import org.hidetake.groovy.ssh.session.execution.Command
-import org.hidetake.groovy.ssh.session.execution.Shell
-import org.hidetake.groovy.ssh.session.execution.Sudo
+import org.hidetake.groovy.ssh.session.execution.*
 import org.hidetake.groovy.ssh.session.forwarding.PortForward
 import org.hidetake.groovy.ssh.session.transfer.FileGet
 import org.hidetake.groovy.ssh.session.transfer.FilePut
@@ -17,6 +14,7 @@ import org.hidetake.groovy.ssh.session.transfer.SftpRemove
 trait SessionExtensions implements
         Command,
         BackgroundCommand,
+        Script,
         Shell,
         Sudo,
         FileGet,

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/Script.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/Script.groovy
@@ -1,0 +1,59 @@
+package org.hidetake.groovy.ssh.session.execution
+
+import groovy.util.logging.Slf4j
+
+/**
+ * An extension class for script execution.
+ *
+ * @author Hidetake Iwata
+ */
+@Slf4j
+trait Script implements Command {
+
+    String executeScript(HashMap settings = [:], String script) {
+        assert script, 'script must be given'
+        execute(Helper.createSettings(settings, script), Helper.guessInterpreter(script))
+    }
+
+    void executeScript(HashMap settings = [:], String script, Closure callback) {
+        assert script, 'script must be given'
+        execute(Helper.createSettings(settings, script), Helper.guessInterpreter(script), callback)
+    }
+
+    String executeScript(HashMap settings = [:], File script) {
+        assert script, 'script must be given'
+        execute(Helper.createSettings(settings, script), Helper.guessInterpreter(script))
+    }
+
+    void executeScript(HashMap settings = [:], File script, Closure callback) {
+        assert script, 'script must be given'
+        execute(Helper.createSettings(settings, script), Helper.guessInterpreter(script), callback)
+    }
+
+    private static class Helper {
+        static HashMap createSettings(HashMap settings, String script) {
+            if (settings.inputStream) {
+                throw new IllegalArgumentException("executeScript does not work with inputStream: $settings")
+            }
+            [:] << settings << [inputStream: script] as HashMap
+        }
+
+        static HashMap createSettings(HashMap settings, File script) {
+            if (settings.inputStream) {
+                throw new IllegalArgumentException("executeScript does not work with inputStream: $settings")
+            }
+            [:] << settings << [inputStream: script.newInputStream()] as HashMap
+        }
+
+        static String guessInterpreter(String script) {
+            script.find(~/^#!.+/) { m -> m.substring(2) } ?: '/bin/sh'
+        }
+
+        static String guessInterpreter(File script) {
+            script.withReader { reader ->
+                reader.readLine().find(~/^#!.+/) { m -> m.substring(2) }
+            } ?: '/bin/sh'
+        }
+    }
+
+}

--- a/docs/src/docs/asciidoc/user-guide.adoc
+++ b/docs/src/docs/asciidoc/user-guide.adoc
@@ -917,6 +917,54 @@ shell ignoreError: true, interaction: {...}
 ----
 
 
+=== Execute a script
+
+Call the `executeScript` method to execute a script.
+The method executes the shell and gives the script through the standard input.
+The shell is guessed from shebang `#!` of the script and defaults to `/bin/sh`.
+
+[source,groovy]
+----
+// execute a script
+executeScript '''#!/bin/sh
+echo "Hello World!"
+'''
+
+// execute a script from local file
+executeScript file('deploy.sh')
+
+// execute a script with settings
+executeScript '''#!/bin/sh
+echo "Hello World!"
+''', pty: true
+----
+
+The method waits until the command is completed and returns a result from standard output of the command.
+Line separators are converted to the platform native.
+
+[source,groovy]
+----
+def result = executeScript '''#!/bin/sh
+echo "Hello World!"
+'''
+println result
+----
+
+A result can be retrieved as an argument if a closure is given.
+
+[source,groovy]
+----
+executeScript('''#!/bin/sh
+echo "Hello World!"
+''') { result ->
+  println result
+}
+----
+
+The method throws an exception if it is called with the `inputStream` setting,
+because the script execution is achieved by using the standard input.
+
+
 === Transfer a file or directory
 
 Call the `get` method to get a file or directory from the remote host.

--- a/os-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/os/ScriptSpec.groovy
+++ b/os-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/os/ScriptSpec.groovy
@@ -1,0 +1,34 @@
+package org.hidetake.groovy.ssh.test.os
+
+import org.codehaus.groovy.tools.Utilities
+import org.hidetake.groovy.ssh.Ssh
+import org.hidetake.groovy.ssh.core.Service
+import spock.lang.Specification
+
+import static org.hidetake.groovy.ssh.test.os.Fixture.createRemotes
+
+class ScriptSpec extends Specification {
+
+    Service ssh
+
+    def setup() {
+        ssh = Ssh.newService()
+        createRemotes(ssh)
+    }
+
+    def 'should execute a script'() {
+        when:
+        def actual = ssh.run {
+            session(ssh.remotes.Default) {
+                executeScript '''#!/bin/bash -xe
+echo 1
+echo 2
+'''
+            }
+        }
+
+        then:
+        actual == "1${Utilities.eol()}2"
+    }
+
+}

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ScriptSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ScriptSpec.groovy
@@ -1,0 +1,264 @@
+package org.hidetake.groovy.ssh.test.server
+
+import org.apache.sshd.SshServer
+import org.apache.sshd.server.CommandFactory
+import org.apache.sshd.server.PasswordAuthenticator
+import org.hidetake.groovy.ssh.Ssh
+import org.hidetake.groovy.ssh.core.Service
+import org.junit.ClassRule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import static org.hidetake.groovy.ssh.test.server.CommandHelper.command
+
+class ScriptSpec extends Specification {
+
+    @Shared
+    SshServer server
+
+    Service ssh
+
+    @Shared @ClassRule
+    TemporaryFolder temporaryFolder
+
+    @Shared
+    File scriptFile
+
+    def setupSpec() {
+        server = SshServerMock.setUpLocalhostServer()
+        server.passwordAuthenticator = Mock(PasswordAuthenticator) {
+            authenticate('someuser', 'somepassword', _) >> true
+        }
+        server.start()
+
+        scriptFile = temporaryFolder.newFile() << 'foo!'
+    }
+
+    def cleanupSpec() {
+        new PollingConditions().eventually {
+            assert server.activeSessions.empty
+        }
+        server.stop()
+    }
+
+    def setup() {
+        server.commandFactory = Mock(CommandFactory)
+
+        ssh = Ssh.newService()
+        ssh.settings {
+            knownHosts = allowAnyHosts
+        }
+        ssh.remotes {
+            testServer {
+                host = server.host
+                port = server.port
+                user = 'someuser'
+                password = 'somepassword'
+            }
+        }
+    }
+
+
+    def "executeScript should execute a script"() {
+        given:
+        def actualScript = new ByteArrayOutputStream()
+
+        when:
+        def actualResult = ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript 'foo!'
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand('/bin/sh') >> command(0) {
+            outputStream << 'something'
+            actualScript << inputStream
+        }
+
+        then:
+        actualResult == 'something'
+        actualScript.toString() == 'foo!'
+    }
+
+    def "executeScript should execute a script from local file"() {
+        given:
+        def actualScript = new ByteArrayOutputStream()
+
+        when:
+        def actualResult = ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript scriptFile
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand('/bin/sh') >> command(0) {
+            outputStream << 'something'
+            actualScript << inputStream
+        }
+
+        then:
+        actualResult == 'something'
+        actualScript.toString() == 'foo!'
+    }
+
+    def "executeScript should execute a script with settings"() {
+        given:
+        def actualScript = new ByteArrayOutputStream()
+
+        when:
+        def actualResult = ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript 'foo!', ignoreError: true
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand('/bin/sh') >> command(1) {
+            outputStream << 'something'
+            actualScript << inputStream
+        }
+
+        then:
+        actualResult == 'something'
+        actualScript.toString() == 'foo!'
+    }
+
+    def "executeScript should execute a script from local file with settings"() {
+        given:
+        def actualScript = new ByteArrayOutputStream()
+
+        when:
+        def actualResult = ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript scriptFile, ignoreError: true
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand('/bin/sh') >> command(1) {
+            outputStream << 'something'
+            actualScript << inputStream
+        }
+
+        then:
+        actualResult == 'something'
+        actualScript.toString() == 'foo!'
+    }
+
+    def "executeScript should return a result of script via closure"() {
+        given:
+        def actualScript = new ByteArrayOutputStream()
+        def actualResult
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript('foo!') { result ->
+                    actualResult = result
+                }
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand('/bin/sh') >> command(0) {
+            outputStream << 'something'
+            actualScript << inputStream
+        }
+
+        then:
+        actualResult == 'something'
+        actualScript.toString() == 'foo!'
+    }
+
+    def "executeScript should return a result of script via closure with settings"() {
+        given:
+        def actualScript = new ByteArrayOutputStream()
+        def actualResult
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript('foo!', ignoreError: true) { result ->
+                    actualResult = result
+                }
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand('/bin/sh') >> command(1) {
+            outputStream << 'something'
+            actualScript << inputStream
+        }
+
+        then:
+        actualResult == 'something'
+        actualScript.toString() == 'foo!'
+    }
+
+    def "executeScript should return a result of script from local file via closure"() {
+        given:
+        def actualScript = new ByteArrayOutputStream()
+        def actualResult
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript(scriptFile) { result ->
+                    actualResult = result
+                }
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand('/bin/sh') >> command(0) {
+            outputStream << 'something'
+            actualScript << inputStream
+        }
+
+        then:
+        actualResult == 'something'
+        actualScript.toString() == 'foo!'
+    }
+
+    def "executeScript should return a result of script from local file via closure with settings"() {
+        given:
+        def actualScript = new ByteArrayOutputStream()
+        def actualResult
+
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript(scriptFile, ignoreError: true) { result ->
+                    actualResult = result
+                }
+            }
+        }
+
+        then:
+        1 * server.commandFactory.createCommand('/bin/sh') >> command(1) {
+            outputStream << 'something'
+            actualScript << inputStream
+        }
+
+        then:
+        actualResult == 'something'
+        actualScript.toString() == 'foo!'
+    }
+
+    def "executeScript should throw an error if inputStream is set"() {
+        when:
+        ssh.run {
+            session(ssh.remotes.testServer) {
+                executeScript 'foo!', inputStream: 'bar!'
+            }
+        }
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+}


### PR DESCRIPTION
This adds the feature to execute a script.

### Steps to use the feature | verify the fix
1. Call `executeScript` with a script text or file.


See https://github.com/int128/gradle-ssh-plugin/issues/249.