### PR TITLE
Change inputStream setting accepts File object

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/type/InputStreamValue.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/type/InputStreamValue.groovy
@@ -1,0 +1,46 @@
+package org.hidetake.groovy.ssh.core.type
+
+/**
+ * A value object for
+ * {@link org.hidetake.groovy.ssh.operation.CommandSettings#inputStream},
+ * {@link org.hidetake.groovy.ssh.operation.ShellSettings#inputStream},
+ * {@link org.hidetake.groovy.ssh.session.execution.SudoSettings#inputStream}.
+ *
+ * @author Hidetake Iwata
+ */
+class InputStreamValue {
+
+    private final value
+
+    def InputStreamValue(def value1) {
+        if (value == null ||
+            value instanceof InputStream ||
+            value instanceof byte[] ||
+            value instanceof String ||
+            value instanceof File) {
+            value = value1
+        } else {
+            throw new IllegalArgumentException("inputStream must be InputStream, byte[], String or File: $value1")
+        }
+    }
+
+    boolean asBoolean() {
+        value != null
+    }
+
+    InputStreamValue rightShift(OutputStream stream) {
+        if (value instanceof InputStream) {
+            stream << value
+        } else if (value instanceof byte[]) {
+            stream << value
+        } else if (value instanceof String) {
+            stream << value
+        } else if (value instanceof File) {
+            value.withInputStream {
+                stream << it
+            }
+        }
+        this
+    }
+
+}

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/Command.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/Command.groovy
@@ -4,6 +4,7 @@ import com.jcraft.jsch.ChannelExec
 import groovy.util.logging.Slf4j
 import org.hidetake.groovy.ssh.connection.Connection
 import org.hidetake.groovy.ssh.core.settings.LoggingMethod
+import org.hidetake.groovy.ssh.core.type.InputStreamValue
 import org.hidetake.groovy.ssh.interaction.InteractionHandler
 import org.hidetake.groovy.ssh.interaction.Interactions
 import org.hidetake.groovy.ssh.interaction.Stream
@@ -33,16 +34,11 @@ class Command implements Operation {
 
         interactions = new Interactions(channel.outputStream, channel.inputStream, channel.errStream, settings.encoding)
         if (settings.inputStream) {
+            def inputStreamValue = new InputStreamValue(settings.inputStream)
             interactions.add {
                 standardInput.withStream {
                     log.debug("Sending to standard input on command $connection.remote.name#$channel.id")
-                    try {
-                        standardInput << settings.inputStream
-                    } finally {
-                        if (settings.inputStream instanceof Closeable) {
-                            settings.inputStream.close()
-                        }
-                    }
+                    inputStreamValue >> standardInput
                 }
             }
         }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/CommandSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/CommandSettings.groovy
@@ -35,7 +35,7 @@ trait CommandSettings {
 
     /**
      * An input stream to send to the standard input.
-     * This should be a {@link InputStream}, {@code byte[]} or {@link String}.
+     * This should be a {@link InputStream}, {@code byte[]}, {@link String} or {@link File}.
      */
     def inputStream
 

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/Shell.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/Shell.groovy
@@ -4,6 +4,7 @@ import com.jcraft.jsch.ChannelShell
 import groovy.util.logging.Slf4j
 import org.hidetake.groovy.ssh.connection.Connection
 import org.hidetake.groovy.ssh.core.settings.LoggingMethod
+import org.hidetake.groovy.ssh.core.type.InputStreamValue
 import org.hidetake.groovy.ssh.interaction.InteractionHandler
 import org.hidetake.groovy.ssh.interaction.Interactions
 import org.hidetake.groovy.ssh.interaction.Stream
@@ -28,16 +29,11 @@ class Shell implements Operation {
 
         interactions = new Interactions(channel.outputStream, channel.inputStream, settings.encoding)
         if (settings.inputStream) {
+            def inputStreamValue = new InputStreamValue(settings.inputStream)
             interactions.add {
                 standardInput.withStream {
                     log.debug("Sending to standard input on command $connection.remote.name#$channel.id")
-                    try {
-                        standardInput << settings.inputStream
-                    } finally {
-                        if (settings.inputStream instanceof Closeable) {
-                            settings.inputStream.close()
-                        }
-                    }
+                    inputStreamValue >> standardInput
                 }
             }
         }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/ShellSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/ShellSettings.groovy
@@ -35,7 +35,7 @@ trait ShellSettings {
 
     /**
      * An input stream to send to the standard input.
-     * This should be a {@link InputStream}, {@code byte[]} or {@link String}.
+     * This should be a {@link InputStream}, {@code byte[]}, {@link String} or {@link File}.
      */
     def inputStream
 

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/Script.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/Script.groovy
@@ -31,18 +31,11 @@ trait Script implements Command {
     }
 
     private static class Helper {
-        static HashMap createSettings(HashMap settings, String script) {
+        static HashMap createSettings(HashMap settings, def script) {
             if (settings.inputStream) {
                 throw new IllegalArgumentException("executeScript does not work with inputStream: $settings")
             }
             [:] << settings << [inputStream: script] as HashMap
-        }
-
-        static HashMap createSettings(HashMap settings, File script) {
-            if (settings.inputStream) {
-                throw new IllegalArgumentException("executeScript does not work with inputStream: $settings")
-            }
-            [:] << settings << [inputStream: script.newInputStream()] as HashMap
         }
 
         static String guessInterpreter(String script) {

--- a/docs/src/docs/asciidoc/user-guide.adoc
+++ b/docs/src/docs/asciidoc/user-guide.adoc
@@ -694,7 +694,7 @@ The method accepts following settings:
  Defaults to `slf4j`.
 
 |`inputStream`
-|`InputStream`, `byte[]` or `String`
+|`InputStream`, `byte[]`, `String` or `File`
 |An input data to sent to the standard input of remote command. Defaults to null.
 
 |`outputStream`
@@ -889,7 +889,7 @@ The method accepts following settings:
  Defaults to `slf4j`.
 
 |`inputStream`
-|`InputStream`, `byte[]` or `String`
+|`InputStream`, `byte[]`, `String` or `File`
 |An input data to sent to the standard input of remote command. Defaults to null.
 
 |`outputStream`

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/BackgroundCommandSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/BackgroundCommandSpec.groovy
@@ -10,7 +10,7 @@ import org.hidetake.groovy.ssh.core.settings.LoggingMethod
 import org.hidetake.groovy.ssh.operation.Command
 import org.hidetake.groovy.ssh.session.BackgroundCommandException
 import org.hidetake.groovy.ssh.session.BadExitStatusException
-import org.junit.Rule
+import org.junit.ClassRule
 import org.junit.rules.TemporaryFolder
 import org.slf4j.Logger
 import spock.lang.Shared
@@ -30,7 +30,7 @@ class BackgroundCommandSpec extends Specification {
 
     Service ssh
 
-    @Rule
+    @Shared @ClassRule
     TemporaryFolder temporaryFolder
 
     def setupSpec() {
@@ -403,10 +403,15 @@ class BackgroundCommandSpec extends Specification {
         }
 
         then:
-        actual.toString() == 'some message'
+        actual.toString() == 'some\nmessage'
 
         where:
-        input << [new ByteArrayInputStream('some message'.bytes), 'some message', 'some message'.bytes]
+        input << [
+            new ByteArrayInputStream('some\nmessage'.bytes),
+            'some\nmessage',
+            'some\nmessage'.bytes,
+            temporaryFolder.newFile() << 'some\nmessage',
+        ]
     }
 
 }

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/CommandSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/CommandSpec.groovy
@@ -9,7 +9,7 @@ import org.hidetake.groovy.ssh.core.Service
 import org.hidetake.groovy.ssh.core.settings.LoggingMethod
 import org.hidetake.groovy.ssh.operation.Command
 import org.hidetake.groovy.ssh.session.BadExitStatusException
-import org.junit.Rule
+import org.junit.ClassRule
 import org.junit.rules.TemporaryFolder
 import org.slf4j.Logger
 import spock.lang.Shared
@@ -29,7 +29,7 @@ class CommandSpec extends Specification {
 
     Service ssh
 
-    @Rule
+    @Shared @ClassRule
     TemporaryFolder temporaryFolder
 
     def setupSpec() {
@@ -384,10 +384,15 @@ class CommandSpec extends Specification {
         }
 
         then:
-        actual.toString() == 'some message'
+        actual.toString() == 'some\nmessage'
 
         where:
-        input << [new ByteArrayInputStream('some message'.bytes), 'some message', 'some message'.bytes]
+        input << [
+            new ByteArrayInputStream('some\nmessage'.bytes),
+            'some\nmessage',
+            'some\nmessage'.bytes,
+            temporaryFolder.newFile() << 'some\nmessage',
+        ]
     }
 
 }

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/SudoSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/SudoSpec.groovy
@@ -11,6 +11,8 @@ import org.hidetake.groovy.ssh.interaction.InteractionException
 import org.hidetake.groovy.ssh.operation.Command
 import org.hidetake.groovy.ssh.session.BadExitStatusException
 import org.hidetake.groovy.ssh.session.execution.SudoException
+import org.junit.ClassRule
+import org.junit.rules.TemporaryFolder
 import org.slf4j.Logger
 import spock.lang.Shared
 import spock.lang.Specification
@@ -31,6 +33,9 @@ class SudoSpec extends Specification {
     SshServer server
 
     Service ssh
+
+    @Shared @ClassRule
+    TemporaryFolder temporaryFolder
 
     def setupSpec() {
         server = SshServerMock.setUpLocalhostServer()
@@ -441,7 +446,12 @@ class SudoSpec extends Specification {
         actual.toString() == 'some\nmessage'
 
         where:
-        input << [new ByteArrayInputStream('some\nmessage'.bytes), 'some\nmessage', 'some\nmessage'.bytes]
+        input << [
+            new ByteArrayInputStream('some\nmessage'.bytes),
+            'some\nmessage',
+            'some\nmessage'.bytes,
+            temporaryFolder.newFile() << 'some\nmessage',
+        ]
     }
 
 }


### PR DESCRIPTION
This adds the feature `inputStream` setting accept also File object.


### Steps to use the feature | verify the fix
1. Call `execute inputStream: file(...)`, `shell inputStream: file(...)` or `executeSudo inputStream: file(...)`


### Backward compatibility
No problem.
