### PR TITLE
Automatically add host key to known_hosts

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/AddHostKey.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/AddHostKey.groovy
@@ -1,0 +1,17 @@
+package org.hidetake.groovy.ssh.connection
+
+class AddHostKey {
+
+    final File knownHostsFile
+
+    def AddHostKey(File knownHostsFile1) {
+        knownHostsFile = knownHostsFile1
+        assert knownHostsFile
+    }
+
+    @Override
+    String toString() {
+        "addHostKey($knownHostsFile)"
+    }
+
+}

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/HostAuthenticationPrompt.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/HostAuthenticationPrompt.groovy
@@ -1,0 +1,51 @@
+package org.hidetake.groovy.ssh.connection
+
+import com.jcraft.jsch.UserInfo
+import groovy.util.logging.Slf4j
+
+/**
+ * An implementation of {@link UserInfo} for host key checking.
+ * This should support prompt only for host key checking.
+ *
+ * @author Hidetake Iwata
+ */
+@Slf4j
+class HostAuthenticationPrompt implements UserInfo {
+
+    @Override
+    String getPassphrase() {
+        throw new UnsupportedOperationException('UserInfo#getPassphrase()')
+    }
+
+    @Override
+    String getPassword() {
+        throw new UnsupportedOperationException('UserInfo#getPassword()')
+    }
+
+    @Override
+    boolean promptPassword(String message) {
+        throw new UnsupportedOperationException("UserInfo#promptPassword($message)")
+    }
+
+    @Override
+    boolean promptPassphrase(String message) {
+        throw new UnsupportedOperationException("UserInfo#promptPassphrase($message)")
+    }
+
+    @Override
+    boolean promptYesNo(String message) {
+        if (message.endsWith('Are you sure you want to continue connecting?')) {
+            true
+        } else if (message.endsWith('Do you want to delete the old key and insert the new key?')) {
+            false
+        } else {
+            throw new UnsupportedOperationException("UserInfo#promptYesNo($message)")
+        }
+    }
+
+    @Override
+    void showMessage(String message) {
+        throw new UnsupportedOperationException(message)
+    }
+
+}

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/HostAuthenticationSettings.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/HostAuthenticationSettings.groovy
@@ -15,6 +15,16 @@ trait HostAuthenticationSettings {
     final allowAnyHosts = AllowAnyHosts.instance
 
     /**
+     * Represents that a host key is automatically appended to the known hosts file.
+     * @param knownHostsFile
+     * @return
+     * @see #knownHosts
+     */
+    AddHostKey addHostKey(File knownHostsFile) {
+        new AddHostKey(knownHostsFile)
+    }
+
+    /**
      * Hides constant from result of {@link #toString()}.
      */
     def toString__allowAnyHosts() {}

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/HostKeys.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/HostKeys.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.connection
 
 import com.jcraft.jsch.HostKey
-import com.jcraft.jsch.HostKeyRepository
 import com.jcraft.jsch.JSch
+import com.jcraft.jsch.Session
 import groovy.util.logging.Slf4j
 
 import javax.crypto.Mac
@@ -16,6 +16,7 @@ import javax.crypto.spec.SecretKeySpec
 @Slf4j
 class HostKeys {
 
+    @Delegate
     private final Collection<HostKey> items
 
     def HostKeys(Collection<HostKey> items1) {
@@ -35,19 +36,8 @@ class HostKeys {
         find(host, port)*.type.unique()
     }
 
-    void duplicateForGateway(String host, int port, String gatewayHost, int gatewayPort) {
-        if ([host, port] != [gatewayHost, gatewayPort]) {
-            find(host, port).each { item ->
-                items.add(new HostKey("[$gatewayHost]:$gatewayPort", item.@type, item.@key, item.comment))
-                log.debug("Duplicated host key for gateway: $host:$port -> $gatewayHost:$gatewayPort")
-            }
-        }
-    }
-
-    void addTo(HostKeyRepository repository) {
-        items.each { item ->
-            repository.add(item, null)
-        }
+    static HostKeys fromSession(Session session) {
+        new HostKeys(session.hostKeyRepository.hostKey.toList())
     }
 
     static HostKeys fromKnownHosts(Collection<File> files) {

--- a/docs/src/docs/asciidoc/user-guide.adoc
+++ b/docs/src/docs/asciidoc/user-guide.adoc
@@ -216,8 +216,10 @@ Also following settings can be set in a remote closure.
 |If this is `true`, Putty Agent or ssh-agent is used on authentication. Defaults to `false`.
 
 |`knownHosts`
-|`File` or `List<File>`
-|One or more known hosts files. Defaults to `new File("${System.properties['user.home']}/.ssh/known_hosts")`. If `allowAnyHosts` is set, strict host key checking is turned off (vulnerable to man-in-the-middle attacks).
+|`addHostKey(File)`, `File`, `Collection<File>` or `allowAnyHosts`
+|Known hosts for host key checking.
+ See below section.
+ Defaults to `File("${System.properties['user.home']}/.ssh/known_hosts")`.
 
 |`timeoutSec`
 |`int` (seconds)
@@ -236,7 +238,19 @@ Also following settings can be set in a remote closure.
 |Interval time of keep alive messages sent to the remote host. Defaults to 60 seconds.
 |===
 
-Note that `identity` can be a `File` or `String`.
+These can be set globally in the project as follows.
+
+[source,groovy]
+----
+ssh.settings {
+  timeoutSec = 600
+}
+----
+
+
+==== `identity`: Public key authentication
+
+`identity` should be a `File` or `String`.
 If a `String` is set, it is treated as a content of the private key but not a path.
 
 [source,groovy]
@@ -254,13 +268,36 @@ ssh.settings {
 }
 ----
 
-These can be set globally in the project as follows.
+
+==== `knownHosts`: Host key checking
+
+`knownHosts` should be a `File`, `Collection<File>`, `addHostKey(File)` or `allowAnyHosts`.
+
+If a `File` or `Collection<File>` is set, host key checking is turned on without write access to the file.
+It fails when a host key to connect is different from the file or does not exist in the file.
 
 [source,groovy]
 ----
-ssh.settings {
-  knownHosts = allowAnyHosts
-}
+knownHosts = file('known_hosts')
+
+knownHosts = files('known_hosts', 'known_hosts_additional')
+----
+
+If `addHostKey(File)` is set, host key checking is turned on with write access to the file.
+It fails when a host key to connect is different from the file.
+Any new hosts are automatically appended to the file.
+
+[source,groovy]
+----
+knownHosts = addHostKey(file("$buildDir/known_hosts"))
+----
+
+If `allowAnyHosts` is set, host key checking is turned off.
+It is vulnerable to man-in-the-middle attacks and not recommended for production.
+
+[source,groovy]
+----
+knownHosts = allowAnyHosts
 ----
 
 


### PR DESCRIPTION
This adds the feature to automatically add a host key to the knownHosts file.


### Steps to use the feature
1. Set `knownHosts = addHostKey(new File(...))` in the global, per-method or per-remote settings.


### Backward compatibility
Nothing.
