### PR TITLE
Fix remote name in log message

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ConnectionManager.groovy
@@ -69,9 +69,9 @@ class ConnectionManager implements UserAuthentication, HostAuthentication, Proxy
         validateUserAuthentication(settings, remote)
         validateProxyConnection(settings, remote)
 
-        assert settings.retryCount   >= 0, "retryCount must be zero or positive (remote ${remote.name})"
-        assert settings.retryWaitSec >= 0, "retryWaitSec must be zero or positive (remote ${remote.name})"
-        assert settings.keepAliveSec >= 0, "keepAliveMillis must be zero or positive (remote ${remote.name})"
+        assert settings.retryCount   >= 0, "retryCount must be zero or positive ($remote)"
+        assert settings.retryWaitSec >= 0, "retryWaitSec must be zero or positive ($remote)"
+        assert settings.keepAliveSec >= 0, "keepAliveSec must be zero or positive ($remote)"
 
         retry(settings.retryCount, settings.retryWaitSec) {
             try {

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/HostAuthentication.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/HostAuthentication.groovy
@@ -73,7 +73,7 @@ trait HostAuthentication {
             if (file.createNewFile()) {
                 log.info("Created known-hosts file: $file")
             }
-            log.debug("Using known-hosts file for $remote.name: $file")
+            log.debug("Using known-hosts file for $remote: $file")
             jsch.setKnownHosts(file.path)
             session.setConfig('StrictHostKeyChecking', 'ask')
             configureHostKeyTypes()
@@ -90,7 +90,7 @@ trait HostAuthentication {
         }
 
         void configureHostAuthentication(File file) {
-            log.debug("Using known-hosts file for $remote.name: $file")
+            log.debug("Using known-hosts file for $remote: $file")
             jsch.setKnownHosts(file.path)
             session.setConfig('StrictHostKeyChecking', 'yes')
             configureHostKeyTypes()
@@ -98,7 +98,7 @@ trait HostAuthentication {
         }
 
         void configureHostAuthentication(Collection<File> files) {
-            log.debug("Using known-hosts files for $remote.name: $files")
+            log.debug("Using known-hosts files for $remote: $files")
             def hostKeys = HostKeys.fromKnownHosts(files)
             hostKeys.each { hostKey -> session.hostKeyRepository.add(hostKey, null) }
             session.setConfig('StrictHostKeyChecking', 'yes')
@@ -110,7 +110,7 @@ trait HostAuthentication {
             def keyTypes = HostKeys.fromSession(session).keyTypes(session.host, session.port).join(',')
             if (keyTypes) {
                 session.setConfig('server_host_key', keyTypes)
-                log.debug("Using key exhange algorithm for $remote.name: $keyTypes")
+                log.debug("Using key exhange algorithm for $remote: $keyTypes")
             }
         }
 

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ProxyConnection.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/ProxyConnection.groovy
@@ -28,18 +28,18 @@ trait ProxyConnection {
                     def proxy = new ProxySOCKS5(settings.proxy.host, settings.proxy.port)
                     proxy.setUserPasswd(settings.proxy.user, settings.proxy.password)
                     session.proxy = proxy
-                    log.debug("Using SOCKS5 proxy for $remote.name: $settings.proxy")
+                    log.debug("Using SOCKS5 proxy for $remote: $settings.proxy")
                 } else {
                     def proxy = new ProxySOCKS4(settings.proxy.host, settings.proxy.port)
                     proxy.setUserPasswd(settings.proxy.user, settings.proxy.password)
                     session.proxy = proxy
-                    log.debug("Using SOCKS4 proxy for $remote.name: $settings.proxy")
+                    log.debug("Using SOCKS4 proxy for $remote: $settings.proxy")
                 }
             } else {
                 def proxy = new ProxyHTTP(settings.proxy.host, settings.proxy.port)
                 proxy.setUserPasswd(settings.proxy.user, settings.proxy.password)
                 session.proxy = proxy
-                log.debug("Using HTTP proxy for $remote.name: $settings.proxy")
+                log.debug("Using HTTP proxy for $remote: $settings.proxy")
             }
         }
     }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/UserAuthentication.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/UserAuthentication.groovy
@@ -11,9 +11,9 @@ import org.hidetake.groovy.ssh.core.Remote
 trait UserAuthentication {
 
     void validateUserAuthentication(UserAuthenticationSettings settings, Remote remote) {
-        assert settings.user, "user must be given (remote ${remote.name})"
+        assert settings.user, "user must be given ($remote)"
         assert settings.identity instanceof File || settings.identity instanceof String || settings.identity == null,
-                "identity must be a File, String or null (remote ${remote.name})"
+                "identity must be a File, String or null ($remote)"
     }
 
     void configureUserAuthentication(JSch jsch, Session session, Remote remote, UserAuthenticationSettings settings) {
@@ -21,12 +21,12 @@ trait UserAuthentication {
 
         if (settings.password) {
             session.password = settings.password
-            log.debug("Using password authentication for $remote.name")
+            log.debug("Using password authentication for $remote")
         }
 
         if (settings.agent) {
             jsch.identityRepository = RemoteIdentityRepositoryLocator.get()
-            log.debug("Using SSH agent authentication for $remote.name")
+            log.debug("Using SSH agent authentication for $remote")
         } else {
             jsch.identityRepository = null    /* null means the default repository */
             jsch.removeAllIdentity()
@@ -34,10 +34,10 @@ trait UserAuthentication {
                 final identity = settings.identity
                 if (identity instanceof File) {
                     jsch.addIdentity(identity.path, settings.passphrase as String)
-                    log.debug("Using public key authentication for $remote.name: $identity.path")
+                    log.debug("Using public key authentication for $remote: $identity.path")
                 } else if (identity instanceof String) {
                     jsch.addIdentity("identity-${identity.hashCode()}", identity.bytes, null, settings.passphrase?.bytes)
-                    log.debug("Using public key authentication for $remote.name")
+                    log.debug("Using public key authentication for $remote")
                 }
             }
         }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/core/RunHandler.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/core/RunHandler.groovy
@@ -40,7 +40,7 @@ class RunHandler {
      */
     void session(Remote remote, @DelegatesTo(SessionHandler) Closure closure) {
         assert remote, 'remote must be given'
-        assert remote.host, "host must be given for the remote ${remote.name}"
+        assert remote.host, "host must be given ($remote)"
         assert closure, 'closure must be given'
         sessions.add(new Plan(remote, closure))
     }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/DefaultOperations.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/DefaultOperations.groovy
@@ -34,37 +34,29 @@ class DefaultOperations implements Operations {
 
     @Override
     Operation shell(ShellSettings settings) {
-        log.debug("Executing shell on $remote.name: $settings")
+        log.debug("Executing shell on $remote: $settings")
         new Shell(connection, settings)
     }
 
     @Override
     Operation command(CommandSettings settings, String commandLine) {
-        log.debug("Executing command on $remote.name: $commandLine: $settings")
+        log.debug("Executing command on $remote: $commandLine: $settings")
         new Command(connection, settings, commandLine)
     }
 
     @Override
     int forwardLocalPort(LocalPortForwardSettings settings) {
-        log.debug("Requesting port forwarding " +
-                  "from $settings.bind:$settings.port " +
-                  "to $remote.name [$settings.host:$settings.hostPort]")
+        log.debug("Requesting local port forwarding on $remote with ${new LocalPortForwardSettings.With(settings)}")
         int port = connection.forwardLocalPort(settings)
-        log.info("Enabled port forwarding " +
-                 "from $settings.bind:$settings.port " +
-                 "to $remote.name [$settings.host:$settings.hostPort]")
+        log.info("Enabled local port forwarding on $remote with ${new LocalPortForwardSettings.With(settings)}")
         port
     }
 
     @Override
     void forwardRemotePort(RemotePortForwardSettings settings) {
-        log.debug("Requesting port forwarding " +
-                  "from $remote.name [$settings.bind:$settings.port] " +
-                  "to $settings.host:$settings.hostPort")
+        log.debug("Requesting remote port forwarding on $remote with ${new RemotePortForwardSettings.With(settings)}")
         connection.forwardRemotePort(settings)
-        log.info("Enabled port forwarding from " +
-                 "from $remote.name [$settings.bind:$settings.port] " +
-                 "to $settings.host:$settings.hostPort")
+        log.info("Enabled remote port forwarding from on $remote with ${new RemotePortForwardSettings.With(settings)}")
     }
 
     @Override

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/DryRunOperations.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/DryRunOperations.groovy
@@ -34,17 +34,13 @@ class DryRunOperations implements Operations {
 
     @Override
     int forwardLocalPort(LocalPortForwardSettings settings) {
-        log.info("Requesting port forwarding from " +
-                 "local (${settings.bind}:${settings.port}) to remote (${settings.host}:${settings.hostPort})" +
-                 "on $remote")
+        log.info("Requesting local port forwarding on $remote with ${new LocalPortForwardSettings.With(settings)}")
         0
     }
 
     @Override
     void forwardRemotePort(RemotePortForwardSettings settings) {
-        log.info("Requesting port forwarding from " +
-                 "remote (${settings.bind}:${settings.port}) to local (${settings.host}:${settings.hostPort})" +
-                 "on $remote")
+        log.info("Requesting remote port forwarding on $remote with ${new RemotePortForwardSettings.With(settings)}")
     }
 
     @Override

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/SudoHelper.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/execution/SudoHelper.groovy
@@ -37,16 +37,16 @@ class SudoHelper {
         final command = operations.command(commandSettings, sudoCommandLine)
         command.addInteraction {
             when(partial: prompt, from: standardOutput) {
-                log.info("Providing password for sudo prompt on $operations.remote.name")
+                log.info("Providing password for sudo prompt on $operations.remote")
                 standardInput << sudoSettings.sudoPassword << '\n'
                 standardInput.flush()
 
                 when(line: _, from: standardOutput) {
-                    log.debug("Got ACK to the password on $operations.remote.name")
+                    log.debug("Got ACK to the password on $operations.remote")
 
                     if (inputStreamValue) {
                         standardInput.withStream {
-                            log.debug("Sending to standard input on $operations.remote.name")
+                            log.debug("Sending to standard input on $operations.remote")
                             inputStreamValue >> standardInput
                         }
                     }
@@ -56,7 +56,7 @@ class SudoHelper {
                         lines << it
 
                         when(partial: prompt, from: standardOutput) {
-                            log.error("Failed sudo authentication on $operations.remote.name")
+                            log.error("Failed sudo authentication on $operations.remote")
                             throw new SudoException(operations.remote, lines.join('\n'))
                         }
 


### PR DESCRIPTION
This improves log messages to include remote host name and address, excluding file transfer logs for readability.