### PR TITLE
Remove Java 6 support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,8 @@
 machine:
   java:
-    version: openjdk7
+    version: openjdk8
   environment:
+    JAVA_HOME_7: /usr/lib/jvm/java-7-openjdk-amd64
     TERM: dumb
     GRADLE_OPTS: -Xmx1g -Xms1g
   hosts:

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -4,8 +4,13 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_6
-targetCompatibility = JavaVersion.VERSION_1_6
+configure([compileJava, compileGroovy]) {
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
+    if (System.getenv('JAVA_HOME_7')) {
+        options.bootClasspath = "${System.getenv('JAVA_HOME_7')}/jre/lib/rt.jar"
+    }
+}
 
 mainClassName = 'org.hidetake.groovy.ssh.Main'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,8 +4,13 @@ plugins {
     id 'com.jfrog.bintray' version '1.4'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_6
-targetCompatibility = JavaVersion.VERSION_1_6
+configure([compileJava, compileGroovy]) {
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
+    if (System.getenv('JAVA_HOME_7')) {
+        options.bootClasspath = "${System.getenv('JAVA_HOME_7')}/jre/lib/rt.jar"
+    }
+}
 
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.7'

--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -6,7 +6,7 @@
 
 Gradle SSH Plugin requires following:
 
-* Java 6 or later
+* Java 7 or later
 * Gradle 2.0 or later (Gradle 1.x is also supported with the backport library)
 
 


### PR DESCRIPTION
This removes Java 6 support.

### Backward compatibility

Only run on Java 7 or later.