### PR TITLE
Use groovy-ssh-acceptance-test branch for breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ We can run the OS integration test using OpenSSH server as follows:
 We can run the test with Gradle SSH Plugin.
 See `plugin-integration/run-plugin-integration-test.sh` for details.
 
+If you are planning to release with specification change breaking backward compatibility,
+create `groovy-ssh-acceptance-test` branch on Gradle SSH Plugin to pass the acceptance test.
+
 
 ### Release
 

--- a/plugin-integration/run-plugin-integration-test.sh
+++ b/plugin-integration/run-plugin-integration-test.sh
@@ -1,7 +1,18 @@
 #!/bin/bash -xe
 
+function checkout_remote_branch () {
+  local branch_name="$1"
+  git fetch origin -v "$branch_name:$branch_name"
+  git checkout "$branch_name"
+}
+
 cd "$(dirname $0)/gradle-ssh-plugin"
 git reset --hard
+
+if checkout_remote_branch groovy-ssh-acceptance-test
+then
+  echo 'Use dedicated branch for specification change breaking backward compatibility'
+fi
 
 sed -i -e "s,groovy-ssh:[0-9.]*,groovy-ssh:${CIRCLE_TAG:-SNAPSHOT},g" core/build.gradle
 echo 'repositories.mavenLocal()' >> core/build.gradle


### PR DESCRIPTION
This improves the plugin integration test to pass CI if a branch has breaking changes.


### Steps to use the feature
1. Create `groovy-ssh-acceptance-test` branch on Gradle SSH Plugin repository.
2. Make a pull request on Groovy SSH.


### Backward compatibility
None.
