### PR TITLE
Bump version of sshd-core

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpException.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpException.groovy
@@ -10,18 +10,11 @@ import com.jcraft.jsch.SftpException as JschSftpException
 class SftpException extends Exception {
     final SftpError error
 
-    static SftpException createFrom(JschSftpException cause, String contextMessage) {
-        def sftpError = SftpError.find(cause.id)
-        if (sftpError == SftpError.SSH_FX_NO_SUCH_FILE) {
-            new SftpNoSuchFileException(contextMessage, cause)
-        } else if (sftpError == SftpError.SSH_FX_FAILURE) {
-            new SftpFailureException(contextMessage, cause)
-        } else {
-            new SftpException(contextMessage, cause, sftpError)
-        }
+    def SftpException(String contextMessage, JschSftpException cause) {
+        this(contextMessage, cause, SftpError.find(cause.id))
     }
 
-    protected def SftpException(String contextMessage, JschSftpException cause, SftpError error) {
+    def SftpException(String contextMessage, JschSftpException cause, SftpError error) {
         super("$contextMessage: (${error.name()}: ${error.message}): ${cause.message}", cause)
         this.error = error
     }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpFailureException.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpFailureException.groovy
@@ -1,9 +1,0 @@
-package org.hidetake.groovy.ssh.operation
-
-import com.jcraft.jsch.SftpException as JschSftpException
-
-class SftpFailureException extends SftpException {
-    SftpFailureException(String contextMessage, JschSftpException cause) {
-        super(contextMessage, cause, SftpError.SSH_FX_FAILURE)
-    }
-}

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpNoSuchFileException.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpNoSuchFileException.groovy
@@ -1,9 +1,0 @@
-package org.hidetake.groovy.ssh.operation
-
-import com.jcraft.jsch.SftpException as JschSftpException
-
-class SftpNoSuchFileException extends SftpException {
-    def SftpNoSuchFileException(String contextMessage, JschSftpException cause) {
-        super(contextMessage, cause, SftpError.SSH_FX_NO_SUCH_FILE)
-    }
-}

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpOperations.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpOperations.groovy
@@ -160,7 +160,7 @@ class SftpOperations {
             result
         } catch (JschSftpException e) {
             log.error("Failed $operationMessage")
-            throw SftpException.createFrom(e, "Failed $operationMessage")
+            throw new SftpException("Failed $operationMessage", e)
         }
     }
 }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/transfer/SftpRemove.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/transfer/SftpRemove.groovy
@@ -1,7 +1,8 @@
 package org.hidetake.groovy.ssh.session.transfer
 
 import groovy.util.logging.Slf4j
-import org.hidetake.groovy.ssh.operation.SftpNoSuchFileException
+import org.hidetake.groovy.ssh.operation.SftpError
+import org.hidetake.groovy.ssh.operation.SftpException
 import org.hidetake.groovy.ssh.session.SessionExtension
 
 import static org.hidetake.groovy.ssh.util.Utility.currySelf
@@ -68,8 +69,12 @@ trait SftpRemove implements SessionExtension {
         static <T> T nullIfNoSuchFile(Closure<T> closure) {
             try {
                 closure()
-            } catch (SftpNoSuchFileException ignore) {
-                null
+            } catch (SftpException e) {
+                if (e.error == SftpError.SSH_FX_NO_SUCH_FILE) {
+                    null
+                } else {
+                    throw e
+                }
             }
         }
     }

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/transfer/put/Sftp.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/transfer/put/Sftp.groovy
@@ -2,8 +2,11 @@ package org.hidetake.groovy.ssh.session.transfer.put
 
 import groovy.util.logging.Slf4j
 import org.hidetake.groovy.ssh.operation.Operations
-import org.hidetake.groovy.ssh.operation.SftpFailureException
+import org.hidetake.groovy.ssh.operation.SftpException
 import org.hidetake.groovy.ssh.session.transfer.FileTransferSettings
+
+import static org.hidetake.groovy.ssh.operation.SftpError.SSH_FX_FAILURE
+import static org.hidetake.groovy.ssh.operation.SftpError.SSH_FX_FILE_ALREADY_EXISTS
 
 /**
  * Recursive SFTP PUT executor.
@@ -47,8 +50,12 @@ class Sftp implements Provider {
                         def remoteDir = "$remotePath/$directory.name"
                         try {
                             mkdir(remoteDir)
-                        } catch (SftpFailureException ignore) {
-                            log.info("Remote directory already exists on $remote.name: $remoteDir")
+                        } catch (SftpException e) {
+                            if (e.error in [SSH_FX_FILE_ALREADY_EXISTS, SSH_FX_FAILURE]) {
+                                log.info("Remote directory already exists on $remote.name: $remoteDir")
+                            } else {
+                                throw e
+                            }
                         }
                         directoryStack.push(directory.name)
                         break

--- a/server-integration-test/build.gradle
+++ b/server-integration-test/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     compile project(':core')
-    compile 'org.apache.sshd:sshd-core:0.14.0'
+    compile 'org.apache.sshd:sshd-core:1.3.0'
 
     runtime 'org.bouncycastle:bcpkix-jdk15on:1.51'
 

--- a/server-integration-test/src/main/groovy/org/hidetake/groovy/ssh/test/server/HostKeyFixture.groovy
+++ b/server-integration-test/src/main/groovy/org/hidetake/groovy/ssh/test/server/HostKeyFixture.groovy
@@ -1,6 +1,6 @@
 package org.hidetake.groovy.ssh.test.server
 
-import org.apache.sshd.common.keyprovider.FileKeyPairProvider
+import org.apache.sshd.common.util.SecurityUtils
 
 class HostKeyFixture {
 
@@ -17,9 +17,10 @@ class HostKeyFixture {
     }
 
     static keyPairProvider(List<String> keyTypes) {
-        new FileKeyPairProvider(keyTypes.collect { keyType ->
-            HostKeyFixture.getResource("/hostkey_$keyType").file
-        } as String[])
+        def keyPairProvider = SecurityUtils.createClassLoadableResourceKeyPairProvider()
+        keyPairProvider.resourceLoader = HostKeyFixture.classLoader
+        keyPairProvider.resources = keyTypes.collect { "hostkey_$it".toString() }
+        keyPairProvider
     }
 
 }

--- a/server-integration-test/src/main/groovy/org/hidetake/groovy/ssh/test/server/SshServerMock.groovy
+++ b/server-integration-test/src/main/groovy/org/hidetake/groovy/ssh/test/server/SshServerMock.groovy
@@ -1,10 +1,10 @@
 package org.hidetake.groovy.ssh.test.server
 
 import groovy.util.logging.Slf4j
-import org.apache.sshd.SshServer
-import org.apache.sshd.common.KeyPairProvider
+import org.apache.sshd.common.keyprovider.KeyPairProvider
+import org.apache.sshd.server.SshServer
 
-import static org.apache.sshd.common.KeyPairProvider.SSH_DSS
+import static org.apache.sshd.common.keyprovider.KeyPairProvider.SSH_DSS
 import static org.hidetake.groovy.ssh.test.server.HostKeyFixture.keyPairProvider
 
 /**

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/AbstractFileTransferSpecification.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/AbstractFileTransferSpecification.groovy
@@ -1,7 +1,7 @@
 package org.hidetake.groovy.ssh.test.server
 
-import org.apache.sshd.SshServer
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import org.junit.ClassRule

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/CommandSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/CommandSpec.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.test.server
 
-import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
 import org.codehaus.groovy.tools.Utilities
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ExtensionSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ExtensionSpec.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.test.server
 
-import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import spock.lang.Shared

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/GatewaySpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/GatewaySpec.groovy
@@ -1,10 +1,10 @@
 package org.hidetake.groovy.ssh.test.server
 
-import org.apache.sshd.SshServer
 import org.apache.sshd.common.Factory
-import org.apache.sshd.common.ForwardingFilter
-import org.apache.sshd.common.SshdSocketAddress
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.common.util.net.SshdSocketAddress
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.forward.ForwardingFilter
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import org.junit.ClassRule
@@ -13,7 +13,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
-import static org.apache.sshd.common.KeyPairProvider.*
+import static org.apache.sshd.common.keyprovider.KeyPairProvider.*
 import static org.hidetake.groovy.ssh.test.server.CommandHelper.command
 import static org.hidetake.groovy.ssh.test.server.HostKeyFixture.keyPairProvider
 import static org.hidetake.groovy.ssh.test.server.HostKeyFixture.publicKey
@@ -94,7 +94,7 @@ class GatewaySpec extends Specification {
         }
 
         then: (1.._) * gateway1Server.passwordAuthenticator.authenticate("gateway1User", "gateway1Password", _) >> true
-        then: 1 * gateway1Server.tcpipForwardingFilter.canConnect(addressOf(targetServer), _) >> true
+        then: 1 * gateway1Server.tcpipForwardingFilter.canConnect(_, addressOf(targetServer), _) >> true
         then: (1.._) * targetServer.passwordAuthenticator.authenticate("targetUser", "targetPassword", _) >> true
         then: 1 * targetServer.shellFactory.create() >> command(0)
 
@@ -137,7 +137,7 @@ class GatewaySpec extends Specification {
         }
 
         then: (1.._) * gateway1Server.passwordAuthenticator.authenticate("gateway1User", "gateway1Password", _) >> true
-        then: (1.._) * gateway1Server.tcpipForwardingFilter.canConnect(addressOf(targetServer), _) >> true
+        then: (1.._) * gateway1Server.tcpipForwardingFilter.canConnect(_, addressOf(targetServer), _) >> true
         then: (1.._) * targetServer.passwordAuthenticator.authenticate("targetUser", "targetPassword", _) >> true
         then: 1 * targetServer.shellFactory.create() >> command(0)
 
@@ -188,9 +188,9 @@ class GatewaySpec extends Specification {
         }
 
         then: (1.._) * gateway1Server.passwordAuthenticator.authenticate("gateway1User", "gateway1Password", _) >> true
-        then: 1 * gateway1Server.tcpipForwardingFilter.canConnect(addressOf(gateway2Server), _) >> true
+        then: 1 * gateway1Server.tcpipForwardingFilter.canConnect(_, addressOf(gateway2Server), _) >> true
         then: (1.._) * gateway2Server.passwordAuthenticator.authenticate("gateway2User", "gateway2Password", _) >> true
-        then: 1 * gateway2Server.tcpipForwardingFilter.canConnect(addressOf(targetServer), _) >> true
+        then: 1 * gateway2Server.tcpipForwardingFilter.canConnect(_, addressOf(targetServer), _) >> true
         then: (1.._) * targetServer.passwordAuthenticator.authenticate("targetUser", "targetPassword", _) >> true
         then: 1 * targetServer.shellFactory.create() >> command(0)
 
@@ -241,9 +241,9 @@ class GatewaySpec extends Specification {
         }
 
         then: (1.._) * gateway1Server.passwordAuthenticator.authenticate("gateway1User", "gateway1Password", _) >> true
-        then: (1.._) * gateway1Server.tcpipForwardingFilter.canConnect(addressOf(gateway2Server), _) >> true
+        then: (1.._) * gateway1Server.tcpipForwardingFilter.canConnect(_, addressOf(gateway2Server), _) >> true
         then: (1.._) * gateway2Server.passwordAuthenticator.authenticate("gateway2User", "gateway2Password", _) >> true
-        then: (1.._) * gateway2Server.tcpipForwardingFilter.canConnect(addressOf(targetServer), _) >> true
+        then: (1.._) * gateway2Server.tcpipForwardingFilter.canConnect(_, addressOf(targetServer), _) >> true
         then: (1.._) * targetServer.passwordAuthenticator.authenticate("targetUser", "targetPassword", _) >> true
         then: 1 * targetServer.shellFactory.create() >> command(0)
 

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/HostAuthenticationSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/HostAuthenticationSpec.groovy
@@ -2,9 +2,9 @@ package org.hidetake.groovy.ssh.test.server
 
 import com.jcraft.jsch.JSchException
 import groovy.util.logging.Slf4j
-import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import org.junit.ClassRule
@@ -17,7 +17,7 @@ import spock.util.concurrent.PollingConditions
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
-import static org.apache.sshd.common.KeyPairProvider.*
+import static org.apache.sshd.common.keyprovider.KeyPairProvider.*
 import static org.hidetake.groovy.ssh.test.server.CommandHelper.command
 import static org.hidetake.groovy.ssh.test.server.HostKeyFixture.*
 

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ParallelSessionsSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ParallelSessionsSpec.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.test.server
 
-import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.ParallelSessionsException
 import org.hidetake.groovy.ssh.core.Service

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/PortForwardingSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/PortForwardingSpec.groovy
@@ -5,9 +5,9 @@ import com.sun.net.httpserver.HttpServer
 import groovy.util.logging.Slf4j
 import groovyx.net.http.HttpResponseDecorator
 import groovyx.net.http.RESTClient
-import org.apache.sshd.SshServer
-import org.apache.sshd.common.ForwardingFilter
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.forward.ForwardingFilter
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import spock.lang.Shared
@@ -38,7 +38,7 @@ class PortForwardingSpec extends Specification {
             authenticate("someUser", "somePassword", _) >> true
         }
         sshServer.tcpipForwardingFilter = Mock(ForwardingFilter) {
-            canConnect(_, _) >> true
+            canConnect(_, _, _) >> true
             canListen(_, _) >> true
         }
         sshServer.start()

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/RetrySpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/RetrySpec.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.test.server
 
 import com.jcraft.jsch.JSchException
-import org.apache.sshd.SshServer
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import spock.lang.Shared

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ScpSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ScpSpec.groovy
@@ -1,6 +1,6 @@
 package org.hidetake.groovy.ssh.test.server
 
-import org.apache.sshd.server.command.ScpCommandFactory
+import org.apache.sshd.server.scp.ScpCommandFactory
 import org.hidetake.groovy.ssh.session.transfer.FileTransferMethod
 import spock.lang.Timeout
 

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ScriptSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ScriptSpec.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.test.server
 
-import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import spock.lang.Shared

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/SftpRemoveSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/SftpRemoveSpec.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.test.server
 
-import org.apache.sshd.SshServer
-import org.apache.sshd.server.PasswordAuthenticator
-import org.apache.sshd.server.sftp.SftpSubsystem
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import org.junit.ClassRule
@@ -32,7 +32,7 @@ class SftpRemoveSpec extends Specification {
         server.passwordAuthenticator = Mock(PasswordAuthenticator) {
             (1.._) * authenticate('someuser', 'somepassword', _) >> true
         }
-        server.subsystemFactories = [new SftpSubsystem.Factory()]
+        server.subsystemFactories = [new SftpSubsystemFactory()]
         server.start()
     }
 

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/SftpSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/SftpSpec.groovy
@@ -1,13 +1,13 @@
 package org.hidetake.groovy.ssh.test.server
 
 import com.jcraft.jsch.JSchException
-import org.apache.sshd.server.sftp.SftpSubsystem
+import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory
 import org.hidetake.groovy.ssh.operation.SftpException
 
 class SftpSpec extends AbstractFileTransferSpecification {
 
     def setupSpec() {
-        server.subsystemFactories = [new SftpSubsystem.Factory()]
+        server.subsystemFactories = [new SftpSubsystemFactory()]
         server.start()
     }
 

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ShellSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/ShellSpec.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.groovy.ssh.test.server
 
-import org.apache.sshd.SshServer
 import org.apache.sshd.common.Factory
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import org.hidetake.groovy.ssh.core.settings.LoggingMethod

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/SudoSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/SudoSpec.groovy
@@ -1,9 +1,9 @@
 package org.hidetake.groovy.ssh.test.server
 
 import groovy.util.logging.Slf4j
-import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
-import org.apache.sshd.server.PasswordAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
 import org.codehaus.groovy.tools.Utilities
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/TimeoutSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/TimeoutSpec.groovy
@@ -1,11 +1,11 @@
 package org.hidetake.groovy.ssh.test.server
 
 import com.jcraft.jsch.JSchException
-import org.apache.sshd.SshServer
 import org.apache.sshd.common.Factory
 import org.apache.sshd.server.CommandFactory
-import org.apache.sshd.server.PasswordAuthenticator
-import org.apache.sshd.server.sftp.SftpSubsystem
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import spock.lang.Shared
@@ -136,7 +136,7 @@ class TimeoutSpec extends Specification {
 
     def 'should reach channel timeout set by timeoutSec on sftp()'() {
         given:
-        server.subsystemFactories = [Mock(SftpSubsystem.Factory)]
+        server.subsystemFactories = [Mock(SftpSubsystemFactory)]
         ssh.settings {
             timeoutSec = 1
         }
@@ -152,7 +152,7 @@ class TimeoutSpec extends Specification {
         server.subsystemFactories[0].getName() >> 'sftp'
         server.subsystemFactories[0].create() >> {
             Thread.sleep(2000L)
-            new SftpSubsystem()
+            new SftpSubsystemFactory().create()
         }
 
         then:

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/UserAuthenticationSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/UserAuthenticationSpec.groovy
@@ -1,10 +1,10 @@
 package org.hidetake.groovy.ssh.test.server
 
 import com.jcraft.jsch.JSchException
-import org.apache.sshd.SshServer
 import org.apache.sshd.server.CommandFactory
-import org.apache.sshd.server.PasswordAuthenticator
-import org.apache.sshd.server.PublickeyAuthenticator
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Service
 import spock.lang.Shared


### PR DESCRIPTION
This bumps version of Apache MINA SSHD library.

### Backward compatibility

The exception thrown if a file or directory already exists has been changed from `SSH_FX_FAILURE` to `SSH_FX_FILE_ALREADY_EXISTS` since sshd-core-1.x.
