### PR TITLE
Expose SFTP RENAME support

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpOperations.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/operation/SftpOperations.groovy
@@ -152,6 +152,18 @@ class SftpOperations {
         }
     }
 
+    /**
+     * Rename a remote item.
+     *
+     * @param oldPath
+     * @param newPath
+     */
+    void rename(String oldPath, String newPath) {
+        tryCatchSftpException("SFTP RENAME: $remote.name:$oldPath -> $remote.name:$newPath") {
+            channel.rename(oldPath, newPath)
+        }
+    }        
+
     private static <T> T tryCatchSftpException(String operationMessage, Closure<T> closure) {
         log.debug("Requesting $operationMessage")
         try {


### PR DESCRIPTION
This exposes support for the SFTP `RENAME` command already available in JSch.

My use case for this is a gradle-ssh-plugin deploy script where I want to transfer a directory with lots of files to a temp location, then quickly move it into its final path.

I should note that my host is restrictive and disallows shell access, so I need to use `RENAME` rather than e.g. `execute "mv $old $new"`.

### Steps to use the feature
1. Set up an ssh task in Gradle per [here](https://gradle-ssh-plugin.github.io/)
2. Inside the `session` block create an `sftp` block (hinted at but not really documented in gradle-ssh-plugin docs)
3. Inside the `sftp` block use `rename target source` (params are strings)

```groovy
task publishDocs {
    doLast {
        ssh.run {
            session(remotes.myhost) {
                put from: 'docs', into: tempDir
                sftp {
                    rename "${tempDir}/docs", finalDir
                    rmdir tempDir
                }
            }
        }
    }
}
```

### Backward compatibility
This should have no impact on existing users. The `RENAME` command itself requires support for version 2 of the SFTP protocol, so it is not necessarily supported on all hosts. If the host doesn't support it, an exception will be thrown.