### PR TITLE
Don't SFTP PUT directory contents twice

### DIFF
--- a/core/src/main/groovy/org/hidetake/groovy/ssh/session/transfer/put/Instructions.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/session/transfer/put/Instructions.groovy
@@ -1,5 +1,7 @@
 package org.hidetake.groovy.ssh.session.transfer.put
 
+import groovy.io.FileType
+
 /**
  * Represents a collection of SCP PUT instructions
  * such as {@link File}, {@link StreamContent}, {@link EnterDirectory} or {@link LeaveDirectory}.
@@ -50,7 +52,7 @@ class Instructions implements Iterable {
         if (path.directory) {
             def children = []
             children.add(new EnterDirectory(path.name))
-            path.eachFile { file -> children.addAll(forFileRecursive(file)) }
+            path.eachFile(FileType.FILES) { file -> children.addAll(forFileRecursive(file)) }
             path.eachDir { dir -> children.addAll(forFileRecursive(dir)) }
             children.add(LeaveDirectory.instance)
             children
@@ -74,7 +76,7 @@ class Instructions implements Iterable {
     private static Collection forFileWithFilterRecursive(File path, Closure<Boolean> filter) {
         if (path.directory) {
             def children = new ArrayDeque()
-            path.eachFile { file -> children.addAll(forFileWithFilterRecursive(file, filter)) }
+            path.eachFile(FileType.FILES) { file -> children.addAll(forFileWithFilterRecursive(file, filter)) }
             path.eachDir { dir -> children.addAll(forFileWithFilterRecursive(dir, filter)) }
             if (!children.empty) {
                 children.addFirst(new EnterDirectory(path.name))


### PR DESCRIPTION
This fixes #218 (put method generates "Failed SFTP MKDIR"), int128/gradle-ssh-plugin#285, and potentially #228.

When recursively gathering files to PUT, directory contents are apparently intended to be inspected separately depending on whether the child is a file or a dir:

1. first, child files with `File.eachFile`
2. then child dirs with `File.eachDir`

but [the `File.eachFile` invocation used](http://docs.groovy-lang.org/latest/html/groovy-jdk/java/io/File.html#eachFile(groovy.lang.Closure)) includes both files and directories, thus resulting in directories being gathered twice.

### Steps to verify the fix
1. Use the `FilePut.put` method with a `from` argument indicating a directory tree multiple levels deep
2. Note that prior to the fix, subdirectories were traversed twice, while after the fix they are not (adding a logging statement to the Instructions class constructor makes this more apparent)

```groovy
ssh.run {
  session(remotes.myremote) {
     put from: someFileTree, into: '/remote/dir'
  }
}
```

### Backward compatibility
Other than eliminating redundant traversals, this fix changes the order of traversal: previously all items were traversed in lexicographical order, with directory-children interleaved with regular file-children (and then the directories were traversed a second time). Now, all file-children are traversed first, and then directory-children are traversed. This is what I gleaned to be the original intent of the code, based on the separate calls to `File.eachFile` and `File.eachDir`.