### PR TITLE
Remove --dry-run flag from release script

### DIFF
--- a/.circleci/release-docs.sh
+++ b/.circleci/release-docs.sh
@@ -5,4 +5,4 @@
 ghcp -u gradle-ssh-plugin -r docs -b gh-pages \
   -m "Published by $CIRCLE_BUILD_URL" \
   -C docs/build/asciidoc/html5 \
-  --dry-run .
+  .


### PR DESCRIPTION
This changes the script to publish docs actually.