### PR TITLE
Fix target Java version

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -4,8 +4,9 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '5.0.0'
 }
 
-tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 mainClassName = 'org.hidetake.groovy.ssh.Main'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,8 +4,9 @@ plugins {
     id 'com.jfrog.bintray' version '1.8.4'
 }
 
-tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {


### PR DESCRIPTION
This fixes groovy-ssh and gradle-ssh-plugin do not run on Java 8.

```
% file cli/build/classes/groovy/main/org/hidetake/groovy/ssh/Main.class
cli/build/classes/groovy/main/org/hidetake/groovy/ssh/Main.class: compiled Java class data, version 52.0 (Java 1.8)

% file core/build/classes/groovy/main/org/hidetake/groovy/ssh/Ssh.class
core/build/classes/groovy/main/org/hidetake/groovy/ssh/Ssh.class: compiled Java class data, version 52.0 (Java 1.8)
```

This will fix the issue: https://github.com/int128/gradle-ssh-plugin/issues/328.