### PR TITLE
chore(dependencies): Updated to com.github.mwiede:jsch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from java:8
+from java:11
 
 volume /usr/src/groovy-ssh
 copy . /usr/src/groovy-ssh

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -5,25 +5,25 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 mainClassName = 'org.hidetake.groovy.ssh.Main'
 
 dependencies {
     compile project(':core')
-    compile 'ch.qos.logback:logback-classic:1.1.2'
+    compile 'ch.qos.logback:logback-classic:1.4.4'
 
-    runtime 'commons-cli:commons-cli:1.2'
+    runtime 'commons-cli:commons-cli:1.5.0'
 
     testCompile project(':server-integration-test')
 
     testCompile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
 
-    testCompile 'org.spockframework:spock-core:1.2-groovy-2.5'
-    testRuntime 'cglib:cglib-nodep:3.2.10'
-    testRuntime 'org.objenesis:objenesis:3.0.1'
+    testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'
+    testRuntime 'cglib:cglib-nodep:3.3.0'
+    testRuntime 'org.objenesis:objenesis:3.2'
 }
 
 test {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,18 +5,16 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.5.6'
-    compile 'org.slf4j:slf4j-api:1.7.7'
-    compile 'com.jcraft:jsch:0.1.55'
-    compile 'com.jcraft:jsch.agentproxy.connector-factory:0.0.9'
-    compile 'com.jcraft:jsch.agentproxy.jsch:0.0.9'
+    compile 'org.codehaus.groovy:groovy-all:2.5.19'
+    compile 'org.slf4j:slf4j-api:1.7.36'
+    compile 'com.github.mwiede:jsch:0.2.4'
 
-    testCompile('org.spockframework:spock-core:1.2-groovy-2.5') {
+    testCompile('org.spockframework:spock-core:1.3-groovy-2.5') {
         exclude group: 'org.codehaus.groovy', module:'groovy-all'
     }
     testRuntime 'cglib:cglib-nodep:3.2.10'

--- a/core/src/main/groovy/org/hidetake/groovy/ssh/connection/UserAuthentication.groovy
+++ b/core/src/main/groovy/org/hidetake/groovy/ssh/connection/UserAuthentication.groovy
@@ -1,9 +1,10 @@
 package org.hidetake.groovy.ssh.connection
 
+import com.jcraft.jsch.AgentIdentityRepository
+import com.jcraft.jsch.IdentityRepository
 import com.jcraft.jsch.JSch
+import com.jcraft.jsch.SSHAgentConnector
 import com.jcraft.jsch.Session
-import com.jcraft.jsch.agentproxy.ConnectorFactory
-import com.jcraft.jsch.agentproxy.RemoteIdentityRepository
 import groovy.util.logging.Slf4j
 import org.hidetake.groovy.ssh.core.Remote
 
@@ -25,7 +26,9 @@ trait UserAuthentication {
         }
 
         if (settings.agent) {
-            jsch.identityRepository = RemoteIdentityRepositoryLocator.get()
+            // Use agent authentication using https://github.com/mwiede/jsch/issues/65#issuecomment-913051572
+            IdentityRepository irepo = new AgentIdentityRepository(new SSHAgentConnector())
+            jsch.setIdentityRepository(irepo)
             log.debug("Using SSH agent authentication for $remote")
         } else {
             jsch.identityRepository = null    /* null means the default repository */
@@ -42,17 +45,4 @@ trait UserAuthentication {
             }
         }
     }
-
-    private static class RemoteIdentityRepositoryLocator {
-        private static instance = null
-
-        static get() {
-            if (instance) {
-                instance
-            } else {
-                instance = new RemoteIdentityRepository(ConnectorFactory.default.createConnector())
-            }
-        }
-    }
-
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- See #292, as explained in https://stackoverflow.com/questions/72743823/public-key-authentication-fails-with-jsch-but-work-with-openssh-with-the-same-ke
- Minimum Java version required is now 11
- Package updates (minor)
- Needed for https://github.com/jenkinsci/ssh-steps-plugin, should fix https://issues.jenkins.io/browse/JENKINS-65533?jql=resolution%20is%20EMPTY%20and%20component%3D23921

This a fixes the bug #292 


### Steps to verify the fix
1. SSH connect to a SSH server running OpenSSH 7.8+ with a newer key (e.g. ed25519)

### Backward compatibility
- Dropped Java v8 support