### PR TITLE
Publish to Maven Central

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      VERSION: ${{ github.event.release.tag_name || 'v0.0.0' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -26,18 +28,14 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses: gradle/gradle-build-action@v2
 
-      - if: github.event_name != 'release'
-        run: ./gradlew sign
+      - run: ./gradlew sign
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
 
-      - if: github.event_name == 'release'
+      - #if: github.event_name == 'release'
         run: ./gradlew publish
         env:
-          VERSION: ${{ github.event.release.tag_name }}
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           OSSRH_USER: ${{ secrets.OSSRH_USER }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,14 +11,15 @@ on:
     types:
       - created
 
+env:
+  GROOVY_SSH_VERSION: ${{ github.event.release.tag_name }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    env:
-      VERSION: ${{ github.event.release.tag_name || 'v0.0.0' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          OSSRH_USER: ${{ secrets.OSSRH_USER }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
   cli:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,8 @@ jobs:
       - #if: github.event_name == 'release'
         run: ./gradlew publish
         env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           OSSRH_USER: ${{ secrets.OSSRH_USER }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
 
-      - #if: github.event_name == 'release'
+      - if: github.event_name == 'release'
         run: ./gradlew publish
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,13 +27,19 @@ jobs:
       - uses: gradle/gradle-build-action@v2
 
       - if: github.event_name != 'release'
-        run: ./gradlew generateMetadataFileForMavenPublication generatePomFileForMavenPublication
+        run: ./gradlew sign
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
 
       - if: github.event_name == 'release'
         run: ./gradlew publish
         env:
           VERSION: ${{ github.event.release.tag_name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          OSSRH_USER: ${{ secrets.OSSRH_USER }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
   cli:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
 allprojects {
 	group = 'org.hidetake'
-	version = System.getenv('VERSION') ?: 'SNAPSHOT'
+	version = System.getenv('GROOVY_SSH_VERSION') ?: '0.0.0'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
     id 'groovy'
     id 'maven-publish'
+    id 'signing'
 }
 
 repositories {
@@ -39,11 +40,11 @@ description = 'Groovy SSH library'
 publishing {
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/int128/groovy-ssh"
+            name = "OSSRH"
+            url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
             credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
+                username = System.getenv("OSSRH_USER")
+                password = System.getenv("OSSRH_PASSWORD")
             }
         }
     }
@@ -62,7 +63,23 @@ publishing {
                         url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
+                developers {
+                    developer {
+                        id = 'int128'
+                        name = 'int128'
+                        email = 'int128@gmail.com'
+                    }
+                }
+                scm {
+                    url = 'https://github.com/int128/groovy-ssh'
+                    connection = 'scm:git:https://github.com/int128/groovy-ssh'
+                }
             }
         }
     }
+}
+
+signing {
+    useInMemoryPgpKeys(System.getenv("SIGNING_KEY"), System.getenv("SIGNING_PASSWORD"))
+    sign publishing.publications
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,7 +43,7 @@ publishing {
             name = "OSSRH"
             url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
             credentials {
-                username = System.getenv("OSSRH_USER")
+                username = System.getenv("OSSRH_USERNAME")
                 password = System.getenv("OSSRH_PASSWORD")
             }
         }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -51,6 +51,7 @@ publishing {
 
     publications {
         maven(MavenPublication) {
+            // https://central.sonatype.org/publish/requirements/
             artifactId parent.name
             from components.java
             pom {
@@ -59,14 +60,14 @@ publishing {
                 url = 'https://github.com/int128/groovy-ssh'
                 licenses {
                     license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        name = 'Apache-2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
                 developers {
                     developer {
                         id = 'int128'
-                        name = 'int128'
+                        name = 'Hidetake Iwata'
                         email = 'int128@gmail.com'
                     }
                 }


### PR DESCRIPTION
## Problem to solve
Currently an artifact is published to GitHub Packages as #296, but it requires authentication with a GitHub token. Gradle SSH plugin does not work.
