### PR TITLE
Prep for use with Gradle 8.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,4 +18,4 @@ jobs:
           java-version: 11
       - uses: gradle/wrapper-validation-action@v1
       - uses: gradle/gradle-build-action@v2
-      - run: ./gradlew build
+      - run: ./gradlew build --warning-mode all

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -32,7 +32,7 @@ jar {
 }
 
 shadowJar {
-    baseName = 'gssh'
+    archiveBaseName = 'gssh'
+    archiveVersion = ''
     classifier = ''
-    version = ''
 }


### PR DESCRIPTION
Gradle 8 removes [deprecated](https://docs.gradle.org/7.6.4/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:version) [properties](https://docs.gradle.org/7.6.4/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:baseName) on `AbstractArchiveTask` (used by `shadowJar`). This commit updates relevant code to use the new names of these properties.

Additionally, I added the `--warning-mode all` flag to the Gradle command in CI, so any deprecation notices will actually provide useful information.
