### PR TITLE
updates jsch version and fixes test to match exception correctly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-      - uses: gradle/wrapper-validation-action@v3
-      - uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew build --warning-mode all

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,5 +17,5 @@ jobs:
           distribution: temurin
           java-version: 11
       - uses: gradle/wrapper-validation-action@v3
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/gradle-build-action@v3
       - run: ./gradlew build --warning-mode all

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
           distribution: temurin
           java-version: 11
       - uses: gradle/wrapper-validation-action@v3
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/gradle-build-action@v3
 
       - run: ./gradlew sign
         env:
@@ -54,7 +54,7 @@ jobs:
           distribution: temurin
           java-version: 11
       - uses: gradle/wrapper-validation-action@v3
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/gradle-build-action@v3
       - run: ./gradlew shadowJar
       - run: java -jar cli/build/libs/gssh.jar
       - run: sha256sum -b cli/build/libs/gssh.jar > cli/build/libs/gssh.jar.sha256

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-      - uses: gradle/wrapper-validation-action@v3
-      - uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/setup-gradle@v4
 
       - run: ./gradlew sign
         env:
@@ -53,8 +53,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-      - uses: gradle/wrapper-validation-action@v3
-      - uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew shadowJar
       - run: java -jar cli/build/libs/gssh.jar
       - run: sha256sum -b cli/build/libs/gssh.jar > cli/build/libs/gssh.jar.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 
 .idea
 *.iml
+.vscode/
 
 /plugin-integration/gradle-ssh-plugin
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     api localGroovy()
-    api 'com.github.mwiede:jsch:0.2.5'
+    api 'com.github.mwiede:jsch:0.2.23'
     api 'org.slf4j:slf4j-api:2.0.17'
 
     testImplementation platform("org.spockframework:spock-bom:2.3-groovy-3.0")

--- a/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/UserAuthenticationSpec.groovy
+++ b/server-integration-test/src/test/groovy/org/hidetake/groovy/ssh/test/server/UserAuthenticationSpec.groovy
@@ -304,7 +304,8 @@ class UserAuthenticationSpec extends Specification {
         executeCommand()
 
         then:
-        thrown(IllegalArgumentException)
+        JSchException e = thrown()
+        e.message == 'USERAUTH fail'
     }
 
     def "remote specific identity should precede one in global settings"() {


### PR DESCRIPTION
Fixes #301 
Fixes #308
Fixes #356

* Bumps the JSCH version from `0.2.5` to the latest `0.2.23`. This addresses [CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795) which was fixed in [jsch-0.2.15](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.15) and adds in support for many new algorithms
* Correct test case that fails due to the bump. No implementation code changes needed.
  * This changed in [jsch-0.2.7](https://github.com/mwiede/jsch/releases/tag/jsch-0.2.7) and appears to be done around the following change note (see https://github.com/int128/groovy-ssh/pull/389#issuecomment-2689296370 for more details):
    > Eliminate KeyPairDeferred and instead change handling of OpenSSH V1 type keys to be more like other KeyPair types
* Bumps gradle build action to new implementation. See notes on repos:
  * Old: https://github.com/gradle/wrapper-validation-action
  * New: https://github.com/gradle/actions/tree/main/wrapper-validation
  * Old: https://github.com/gradle/gradle-build-action
  * New: https://github.com/gradle/actions/tree/main/setup-gradle

### Steps to verify the fix
1. Bumped the version
2. Corrected failing test. Was expecting `IllegalArgumentException`, but with the bump a corrected `JSCHException` is thrown with the message "AUTH FAIL"
3. ran `gradle build` and confirmed all tests passed

```groovy
// Paste the snippet
```


### Backward compatibility

If someone is expecting an "IllegalArgumentException" on wrong passphrases for ssh keys, they will need to change their exception to the JSCHException.